### PR TITLE
Update blueprint-whattimeisit.yaml

### DIFF
--- a/View Assist custom sentences/What time is it/blueprint-whattimeisit.yaml
+++ b/View Assist custom sentences/What time is it/blueprint-whattimeisit.yaml
@@ -38,7 +38,7 @@ trigger:
       - !input command_prompt_dayofweek
     id: dayofweek
 variables:
-  view: /dashboard-viewassist/clock
+  view: !input view
   target_satellite_device: |-
     {% for sat in expand('group.viewassist_satellites') %}
       {% if device_id(sat.attributes.mic_device)  == trigger.device_id %}


### PR DESCRIPTION
Fix variable "view" to use the user selected input view and not the hard coded /dashboard-viewassist/clock