### PR TITLE
Fix music stop command blueprint-devicefunctions.yaml

### DIFF
--- a/View Assist custom sentences/Device Functions/blueprint-devicefunctions.yaml
+++ b/View Assist custom sentences/Device Functions/blueprint-devicefunctions.yaml
@@ -228,15 +228,15 @@ action:
             id:
               - stop_music
         sequence:
-          - data:
-              entity_id: "{{ target_satellite_device }}"
-              mode: normal
-            action: python_script.set_state
           - target:
               entity_id:
                 - "{{ target_musicplayer_device }}"
             data: {}
             action: media_player.media_stop
+          - data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: normal
+            action: python_script.set_state
           - action: timer.finish
             target:
               entity_id: "{{ target_timer_device }}"
@@ -256,5 +256,5 @@ variables:
   target_display_device: "{{ device_id(state_attr(target_satellite_device, 'display_device')) }}"
   target_mediaplayer_device: "{{ state_attr(target_satellite_device, 'mediaplayer_device') }}"
   target_musicplayer_device: "{{ state_attr(target_satellite_device, 'musicplayer_device') }}"
-  target_timer_device: "{{ state_attr(target_satellite_device, 'timer') }}"    
+  target_timer_device: "{{ state_attr(target_satellite_device, 'timer_device') }}"    
   target_satellite_device_type: "{{ state_attr(target_satellite_device, 'type') }}"              


### PR DESCRIPTION
Fix music stop command.
Move media_player.stop action to be first in sequence.