### PR TITLE
Update input description blueprint-devicefunctions.yaml

### DIFF
--- a/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
+++ b/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
@@ -21,11 +21,11 @@ blueprint:
       default: "(set do not disturb [mode] [to] off | turn off do not disturb [mode] | end do not disturb [mode] | cancel do not disturb [mode])"
     set_volume:
       name: Set Volume Command 
-      description: The command to use to set volume levels level directly
+      description: The command to use to set volume level directly
       default: "[set | turn] [the] volume [to] {level}"
     adjust_volume:
       name: Adjust Volume Command 
-      description: The command to use to set volume levels by step
+      description: The command to use to set volume level by step
       default: "turn {up_down} [the] volume"      
     mute_volume:
       name: Mute Volume Command 


### PR DESCRIPTION
Removed duplicate word in input description.
&
"Levels" changed to "level" to maintain consistency.

Both "levels" and "level" were used. Which do you prefer?

"Level" makes the most sense to me, as the volume can only be set to one level at a time.