### PR TITLE
more details in conversation response for set mode blueprint-devicefunctions.yaml

### DIFF
--- a/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
+++ b/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
@@ -144,7 +144,7 @@ action:
                           entity_id: " {{ target_satellite_device }} "
                           do_not_disturb: true
             else:
-              - set_conversation_response: "Sorry.  {{ trigger.slots.mode }} is not a valid mode. "
+              - set_conversation_response: "Sorry.  {{ trigger.slots.mode }} is not a valid mode. Please try {{ modes }}."
       - conditions:
           - condition: trigger
             id:


### PR DESCRIPTION
When a nonexistent mode is called, the conversation response will now list the different mode options as they appear in the modes input field.