### PR TITLE
Visible HA Timer

### DIFF
--- a/View Assist device configuration/device_config_example.yaml
+++ b/View Assist device configuration/device_config_example.yaml
@@ -30,6 +30,7 @@ template:
         musicplayer_device: "media_player.browsermod-livingroom_2"
         display_device: "sensor.browsermod-livingroom_browser_path"
         browser_id: "ViewAssist-livingroom"
+        user_timer: "timer.viewassist_livingroom_user_timer"
         timer_device: "timer.viewassist-livingroom"
         view_timeout: "20"
         mode: "normal"

--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
@@ -29,6 +29,18 @@ blueprint:
           filter:
             - domain: group
       default: "group.viewassist_satellites" 
+    timer_view:
+      name: Timer View
+      description: The View Assist dashboard view to use for displaying the timer countdown
+      default: "/dashboard-viewassist/timer"
+    user_timer:
+      name: User Timer
+      description: View Assist user facing timer
+      selector:
+        entity:
+          filter:
+            - domain: timer
+      default: "timer.viewassist_pyramid_user_timer"
 trigger:
   - platform: conversation
     command:
@@ -67,6 +79,10 @@ trigger:
     command:
       - list my timers
     id: listtimer
+  - platform: conversation
+    command:
+      - show {name} timer
+    id: showtimer
 condition: []
 action:
   - variables:
@@ -76,6 +92,7 @@ action:
       snooze_time_input: !input snooze_time
       snooze_time: "{{ snooze_time_input | int }}"
       use_24hr: !input use_24hr
+      timer_view: !input timer_view
   - choose:
       - conditions:
           - condition: trigger
@@ -482,4 +499,36 @@ action:
                 {% set last_timer = timer_names.pop() %}
                 You have {{ timer_count }} active timers and they are {{ timer_names | join(', ') }} and {{ last_timer }}.
               {% endif %}
+      - conditions:
+          - condition: trigger
+            id:
+              - showtimer
+        sequence:
+          - variables:
+              target_satellite_device: |-
+                {% for sat in expand(group_entity) %}
+                  {% if (device_id(sat.attributes.mic_device)  == trigger.device_id) or (device_id(sat.attributes.display_device)  == trigger.device_id) %}
+                    {{ sat.entity_id }}
+                  {% endif %}
+                {% endfor %}
+              target_time: >-
+                {{state_attr(target_satellite_device,'timer_list') |
+                selectattr('timer_id', 'eq', trigger.slots.name)|
+                map(attribute='target_time') | first }}
+            enabled: true
+          - action: pyscript.get_time_difference2
+            data:
+              target_time: "{{ target_time }}"
+            response_variable: time_remaining
+          - service: timer.start
+            data:
+              duration: "{{ time_remaining['formatted_time_difference'] }}"
+            target:
+              entity_id: "{{ state_attr(target_satellite_device, 'user_timer') }}"
+          - data:
+              path: "{{ timer_view }}"
+            target:
+              device_id: "{{device_id(state_attr(target_satellite_device, 'display_device')) }}"
+            action: browser_mod.navigate
+          - set_conversation_response: "showing timer"
 mode: parallel

--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/example_timer_view.yaml
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/example_timer_view.yaml
@@ -1,0 +1,52 @@
+type: custom:button-card
+variables:
+  background: /local/viewassist/vapor_2.jpg
+  cctvversion: 1.0.1
+template:
+  - variable_template
+  - body_template
+styles:
+  card:
+    - background: "[[[ return `center / cover no-repeat url(${variables.background})` ]]]"
+    - background-size: cover
+  custom_fields:
+    message:
+      - position: absolute
+      - width: 75vh
+      - text-align: self
+      - text-wrap: wrap
+      - justify-content: center
+      - align-self: center
+custom_fields:
+  message:
+    card:
+      type: custom:circular-timer-card
+      card_mod:
+        style: |
+          ha-card {
+            color: white !important;
+            background: transparent;
+            --accent-color: red;
+            --primary-color: white;
+            --secondary-text-color: white;
+            --secondary-background-color: red;
+          }
+      entity: timer.viewassist_pyramid_user_timer
+      name: "[[[ return variables.var_alarm_name ]]]"
+      bins: 60
+      pad_angle: 0.5
+      corner_radius: 1
+      color:
+        - "#1e7883"
+        - "#a9bdbb"
+        - "#ee7256"
+      color_state: false
+      empty_bar_color: grey
+      secondary_info_size: 50%
+      layout: circular
+      direction: countdown
+      primary_info: name
+      secondary_info: timer
+      tap_action: toggle
+      hold_action: more_info
+      double_tap_action: cancel

--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/viewassist-timer.py
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/viewassist-timer.py
@@ -57,3 +57,27 @@ def get_time_difference(target_time: str = "") -> dict:
     
     # Return the time difference in a dictionary
     return {"time_difference": time_difference}
+
+@service(supports_response="optional")
+def get_time_difference2(target_time: str = "") -> dict:
+    """yaml
+    name: View Assist Get Time Difference 2
+    description: Returns a human-readable time difference between a given time and now in hh:mm:ss format
+    """  
+    # Parse the target time from the input string
+    target_time = datetime.strptime(target_time, "%Y-%m-%d %H:%M:%S")
+    
+    # Get the current time
+    now = datetime.now()
+    
+    # Calculate the difference as a timedelta object
+    time_difference = target_time - now
+
+    # Format the time difference as hh:mm:ss
+    formatted_time_difference = str(time_difference)
+
+    # Log the time difference
+    log.warning(f"Time difference for target time '{target_time}': {formatted_time_difference}")
+    
+    # Return the formatted time difference in a dictionary
+    return {"formatted_time_difference": formatted_time_difference}


### PR DESCRIPTION
This is just a draft to get all the changes in one place for a better discussion.

**viewassist-timer.py has new service named "get_time_difference2".**
Open to name suggestions.
"get_time_difference2" does the same thing as "get_time_difference" but returns the time difference in HH:MM:SS format to work with the timer.start action.

**blueorint-alarmsreminderstimers.yaml has...**
New inputs:
timer_view (need to create a new view)
user_timer

New trigger

New Variable

New choose option

Creates the ability to start an HA based timer and view that timer on a new view

**VA device config file gets new attribute**
`user_timer: timer.(name)`
Name is work in progress, open to suggestions. Should probably end in _device to maintain consistency.
must also create new timer

**New "Timer" view**
[Uses Circular Timer Card](https://github.com/karlis-vagalis/circular-timer-card)

This is all just a proof of concept to start a discussion on how best to implement the timer.