### PR TITLE
Add Wolfram | Alpha based Custom Sentences

### DIFF
--- a/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/blueprint-askwolfram.yaml
+++ b/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/blueprint-askwolfram.yaml
@@ -1,0 +1,62 @@
+blueprint:
+  name: View Assist - Ask Wolfram
+  description: Ask a question or make a request to Wolfram Alpha's Short Answer API (View Assist Community Contributions - Ask Wolfram v 1.0.0)
+  domain: automation
+  input:
+    command:
+      name: Command
+      description: The phrase you want to use to trigger querying Wolfram Alpha
+      default: "Ask Wolfram [alpha] {question}"
+    view:
+      name: View
+      description: The View Assist dashboard view to use for text information display
+      default: "/dashboard-viewassist/info"
+    group_entity:
+      name: Group Entity
+      description: The group entity that holds the list of ViewAssist devices
+      selector:
+        entity:
+          filter:
+            - domain: group
+      default: "group.viewassist_satellites"
+trigger:
+  - platform: conversation
+    command:
+      - !input command
+condition: []
+action:
+  - variables:
+      group_entity: !input group_entity
+      view: !input view
+      target_satellite_device: |-
+        {% for sat in expand(group_entity) %}
+          {% if device_id(sat.attributes.mic_device)  == trigger.device_id %}
+            {{ sat.entity_id }}
+          {% endif %}
+        {% endfor %}
+      target_display_device: "{{ device_id(state_attr(target_satellite_device, 'display_device')) }}"
+      target_mediaplayer_device: "{{ state_attr(target_satellite_device, 'mediaplayer_device') }}"
+      target_satellite_device_type: "{{ state_attr(target_satellite_device, 'type') }}"
+  - service: pyscript.viewassist_wolfram_short_answer
+    data:
+      query: "{{ trigger.slots.question }}"
+    response_variable: wolfram_answer
+  - set_conversation_response: "{{ wolfram_answer.response }}"
+  - service: python_script.set_state
+    data:
+      entity_id: "{{ target_satellite_device }}"
+      title: Ask Wolfram
+      message_font_size: 4vw
+      message: >-
+        <b>Question</b>: <br /\> {{ trigger.slots.question |capitalize}}?<br /\><br /\> <b>Answer:</b> <br
+        /\> {{ wolfram_answer.response }}
+  - if:
+      - condition: template
+        value_template: "{{ target_satellite_device_type != 'audio_only' }}"
+    then:
+      - service: browser_mod.navigate
+        data:
+          path: "{{ view }}"
+        target:
+          device_id: "{{target_display_device}}"
+mode: single

--- a/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/viewassist-get_wolfram_short_answer.py
+++ b/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/viewassist-get_wolfram_short_answer.py
@@ -1,0 +1,26 @@
+@service(supports_response="optional")
+def viewassist_wolfram_short_answer(query=None, return_response=True):
+    """yaml
+    name: Get short answer
+    description: Gets a response from Wolfram Alpha's Short Answers API
+    fields:
+      query:
+        description: query to be submitted to short answers API
+        example: Convert 2 Tablespoons to teaspoons
+        required: true
+    """
+    appid = "<your app id here>" # see https://products.wolframalpha.com/short-answers-api/documentation
+    parameters = {
+        "appid": appid,
+        "i": query
+    }
+    url = "https://api.wolframalpha.com/v1/result"
+
+    r = task.executor(requests.get, url, params=parameters)
+  
+    if r.status_code == requests.codes.ok:
+        response_variable = {"response": r.text}
+        return response_variable
+    else:
+        response_variable = {"error": r.status_code, "data": {"response": r.text}}
+        return response_variable

--- a/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/viewassist-get_wolfram_short_answer.py
+++ b/View_Assist_custom_sentences/community_contributions/Ask_Wolfram/viewassist-get_wolfram_short_answer.py
@@ -1,3 +1,5 @@
+import requests
+
 @service(supports_response="optional")
 def viewassist_wolfram_short_answer(query=None, return_response=True):
     """yaml

--- a/View_Assist_custom_sentences/community_contributions/Calculations/blueprint-calculations.yaml
+++ b/View_Assist_custom_sentences/community_contributions/Calculations/blueprint-calculations.yaml
@@ -1,0 +1,58 @@
+blueprint:
+  name: View Assist - Calculations
+  description: Calculate the result of a mathematical expression (View Assist Community Contributions - Calculations v 1.0.0)
+  domain: automation
+  input:
+    view:
+      name: View
+      description: The View Assist dashboard view to use for text information display
+      default: "/dashboard-viewassist/info"
+    group_entity:
+      name: Group Entity
+      description: The group entity that holds the list of ViewAssist devices
+      selector:
+        entity:
+          filter:
+            - domain: group
+      default: "group.viewassist_satellites"
+trigger:
+  - platform: conversation
+    command:
+      - "calculate {expression}"
+condition: []
+action:
+  - variables:
+      group_entity: !input group_entity
+      view: !input view
+      target_satellite_device: |-
+        {% for sat in expand(group_entity) %}
+          {% if device_id(sat.attributes.mic_device)  == trigger.device_id %}
+            {{ sat.entity_id }}
+          {% endif %}
+        {% endfor %}
+      target_display_device: "{{ device_id(state_attr(target_satellite_device, 'display_device')) }}"
+      target_mediaplayer_device: "{{ state_attr(target_satellite_device, 'mediaplayer_device') }}"
+      target_satellite_device_type: "{{ state_attr(target_satellite_device, 'type') }}"
+  - service: pyscript.viewassist_wolfram_short_answer
+    data:
+      query: "{{ trigger.slots.expression }}"
+    response_variable: wolfram_answer
+  - set_conversation_response: "The result of {{ trigger.slots.expression }} is {{ wolfram_answer.response }}."
+  - service: python_script.set_state
+    data:
+      entity_id: "{{ target_satellite_device }}"
+      title: Conversion
+      message_font_size: 4vw
+      message: >-
+        <b>Expression</b>: <br /\> {{ trigger.slots.expression }}<br /\><br /\> <b>Answer:</b> <br
+        /\> The result of {{ trigger.slots.expression }} is {{ wolfram_answer.response }}.
+  - if:
+      - condition: template
+        value_template: "{{ target_satellite_device_type != 'audio_only' }}"
+    then:
+      - service: browser_mod.navigate
+        data:
+          path: "{{ view }}"
+        target:
+          device_id: "{{target_display_device}}"
+mode: single

--- a/View_Assist_custom_sentences/community_contributions/Conversions/blueprint-conversions.yaml
+++ b/View_Assist_custom_sentences/community_contributions/Conversions/blueprint-conversions.yaml
@@ -1,0 +1,59 @@
+blueprint:
+  name: View Assist - Conversions
+  description: Convert from one unit of measurement to another (View Assist Community Contributions - Conversions v 1.0.0)
+  domain: automation
+  input:
+    view:
+      name: View
+      description: The View Assist dashboard view to use for text information display
+      default: "/dashboard-viewassist/info"
+    group_entity:
+      name: Group Entity
+      description: The group entity that holds the list of ViewAssist devices
+      selector:
+        entity:
+          filter:
+            - domain: group
+      default: "group.viewassist_satellites"
+trigger:
+  - platform: conversation
+    command:
+      - "convert {source} to {target_unit}"
+      - "how many {target_unit} are in {source}"
+condition: []
+action:
+  - variables:
+      group_entity: !input group_entity
+      view: !input view
+      target_satellite_device: |-
+        {% for sat in expand(group_entity) %}
+          {% if device_id(sat.attributes.mic_device)  == trigger.device_id %}
+            {{ sat.entity_id }}
+          {% endif %}
+        {% endfor %}
+      target_display_device: "{{ device_id(state_attr(target_satellite_device, 'display_device')) }}"
+      target_mediaplayer_device: "{{ state_attr(target_satellite_device, 'mediaplayer_device') }}"
+      target_satellite_device_type: "{{ state_attr(target_satellite_device, 'type') }}"
+  - service: pyscript.viewassist_wolfram_short_answer
+    data:
+      query: "{{ trigger.sentence }}"
+    response_variable: wolfram_answer
+  - set_conversation_response: "{{ wolfram_answer.response }} is eqivalent to {{ trigger.slots.source }}."
+  - service: python_script.set_state
+    data:
+      entity_id: "{{ target_satellite_device }}"
+      title: Conversion
+      message_font_size: 4vw
+      message: >-
+        <b>Request</b>: <br /\> {{ trigger.sentence | capitalize}}<br /\><br /\> <b>Answer:</b> <br
+        /\> {{ wolfram_answer.response }} is eqivalent to {{ trigger.slots.source }}.
+  - if:
+      - condition: template
+        value_template: "{{ target_satellite_device_type != 'audio_only' }}"
+    then:
+      - service: browser_mod.navigate
+        data:
+          path: "{{ view }}"
+        target:
+          device_id: "{{target_display_device}}"
+mode: single

--- a/wiki/docs/community-contributions/cc-sentences/ask-wolfram.md
+++ b/wiki/docs/community-contributions/cc-sentences/ask-wolfram.md
@@ -1,0 +1,19 @@
+---
+title:Ask Wolfram
+---
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FAsk_Wolfram%2Fblueprint-askwolfram.yaml)
+
+This blueprint allows you to directly query Wolfram Alpha's Short Answers API. This is a community contribution authored by user [michelle-avery (Github)](https://github.com/michelle-avery)/miniconfig (Discord). Support can be obtained through the View Assist [Discord server](https://discord.com/channels/1241796965344481440/1295408431498395709) or the [discussion group](https://github.com/dinki/View-Assist/discussions) on Github. Please tag the author in your message.
+
+## Prerequisites
+
+- You must have Pyscript installed [See installation video](https://www.youtube.com/watch?v=jpJxZaisbGQ)
+- You must set up an account and create an API key for Wolfram Alpha's [Short Answers](https://products.wolframalpha.com/short-answers-api/documentation) API. Free API keys are alloted 2,000 calls per month.
+- You must download the [required pyscript](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FAsk_Wolfram%2Fviewassist-get_wolfram_short_answer.py), add your appid to the `appid` parameter, and place this file in your 'pyscripts' directory on your Home Assistant Server. Note that if you have multiple custom sentences using this script, this only needs to be performed once.
+
+## Changelog
+
+| Version | Description     |
+| ------- | --------------- |
+| v 1.0.0 | Initial release |

--- a/wiki/docs/community-contributions/cc-sentences/calculations.md
+++ b/wiki/docs/community-contributions/cc-sentences/calculations.md
@@ -1,0 +1,19 @@
+---
+title:Calculations
+---
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FCalculations%2Fblueprint-calculations.yaml)
+
+This blueprint allows you to calculate the result of a mathematical expression using Wolfram Alpha's Short Answers API. The spoken response includes both the expression and the answer, in order to confirm the user was accurately understood. This is a community contribution authored by user [michelle-avery (Github)](https://github.com/michelle-avery)/miniconfig (Discord). Support can be obtained through the View Assist [Discord server](https://discord.com/channels/1241796965344481440/1295408431498395709) or the [discussion group](https://github.com/dinki/View-Assist/discussions) on Github. Please tag the author in your message.
+
+## Prerequisites
+
+- You must have Pyscript installed [See installation video](https://www.youtube.com/watch?v=jpJxZaisbGQ)
+- You must set up an account and create an API key for Wolfram Alpha's [Short Answers](https://products.wolframalpha.com/short-answers-api/documentation) API. Free API keys are alloted 2,000 calls per month.
+- You must download the [required pyscript](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FAsk_Wolfram%2Fviewassist-get_wolfram_short_answer.py), add your appid to the `appid` parameter, and place this file in your 'pyscripts' directory on your Home Assistant Server. Note that if you have multiple custom sentences using this script, this only needs to be performed once.
+
+## Changelog
+
+| Version | Description     |
+| ------- | --------------- |
+| v 1.0.0 | Initial release |

--- a/wiki/docs/community-contributions/cc-sentences/conversions.md
+++ b/wiki/docs/community-contributions/cc-sentences/conversions.md
@@ -1,0 +1,19 @@
+---
+title:Calculations
+---
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FConversions%2Fblueprint-conversions.yaml)
+
+This blueprint allows you to measurements from one unit to another using Wolfram Alpha's Short Answers API. The spoken response includes both the request and the answer, in order to confirm the user was accurately understood. This is a community contribution authored by user [michelle-avery (Github)](https://github.com/michelle-avery)/miniconfig (Discord). Support can be obtained through the View Assist [Discord server](https://discord.com/channels/1241796965344481440/1295408431498395709) or the [discussion group](https://github.com/dinki/View-Assist/discussions) on Github. Please tag the author in your message.
+
+## Prerequisites
+
+- You must have Pyscript installed [See installation video](https://www.youtube.com/watch?v=jpJxZaisbGQ)
+- You must set up an account and create an API key for Wolfram Alpha's [Short Answers](https://products.wolframalpha.com/short-answers-api/documentation) API. Free API keys are alloted 2,000 calls per month.
+- You must download the [required pyscript](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdinki%2FView-Assist%2Frefs%2Fheads%2Fmain%2FView_Assist_custom_sentences%2Fcommunity_contributions%2FAsk_Wolfram%2Fviewassist-get_wolfram_short_answer.py), add your appid to the `appid` parameter, and place this file in your 'pyscripts' directory on your Home Assistant Server. Note that if you have multiple custom sentences using this script, this only needs to be performed once.
+
+## Changelog
+
+| Version | Description     |
+| ------- | --------------- |
+| v 1.0.0 | Initial release |

--- a/wiki/docs/community-contributions/cc-sentences/index.md
+++ b/wiki/docs/community-contributions/cc-sentences/index.md
@@ -3,16 +3,17 @@ title: Community Contributions Sentences
 sidebar_position: 1
 ---
 
-View Assist is easily extendable by adding custom sentences which provide data to different custom views. On this page you will find a gallery of premade custom sentences provided by our community members. Contained here are custom sentence automations and scripts that do not fit the core of View Assist.  This may be due to the reliance on certain integrations, hardware or conditions that do not make it a fit for core but still provides functionality for those who can apply.  You will find links to the requirements and installation instructions. Blueprints have been made available for easy installation. 
+View Assist is easily extendable by adding custom sentences which provide data to different custom views. On this page you will find a gallery of premade custom sentences provided by our community members. Contained here are custom sentence automations and scripts that do not fit the core of View Assist. This may be due to the reliance on certain integrations, hardware or conditions that do not make it a fit for core but still provides functionality for those who can apply. You will find links to the requirements and installation instructions. Blueprints have been made available for easy installation.
 
 We encourage everyone to share their creations so that others might enjoy what you have brought to life.
-
 
 :::info[Word of Caution]
 These user contributions are supported by the contributors only as they are not a part of the core of View Assist
 :::
 
-
-| Sentence | Description | Github User | Discord User |
-| -------- | ----------- | ----------- | ------------ |
-| [Extended Device Controls](extended-device-controls.md) | Enhances the control of View Assist device displays and audio playback | [Flight-Lab](https://github.com/Flight-Lab) | flab |
+| Sentence                                                | Description                                                                                                                               | Github User                                         | Discord User |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------ |
+| [Extended Device Controls](extended-device-controls.md) | Enhances the control of View Assist device displays and audio playback                                                                    | [Flight-Lab](https://github.com/Flight-Lab)         | flab         |
+| [Ask Wolfram](ask-wolfram.md)                           | Adds the ability to directly query Wolfram Alpha's [Short Answers](https://products.wolframalpha.com/short-answers-api/documentation) API | [michelle-avery](https://github.com/michelle-avery) | miniconfig   |
+| [Calculations](calculations.md)                         | Calculate the result of a mathematical expression                                                                                         | [michelle-avery](https://github.com/michelle-avery) | miniconfig   |
+| [Conversions](conversions.md)                           | Convert from one unit to anaother                                                                                                         | [michelle-avery](https://github.com/michelle-avery) | miniconfig   |


### PR DESCRIPTION
This PR adds a pyscript-based python script to query Wolfram Alpha's Short Answers API, along with three custom sentences blueprints:
* Ask Wolfram works like the Ask AI blueprint and allows the user to ask any question the API supports, preceded by the phrase "Ask Wolfram".
* The  Conversions blueprint uses the same script to support conversions from one unit of measurement to another. This can be done by using the phrase "Convert", or just by asking "How many X are in Y?". 
* The Calculations blueprint uses the same script to evaluate general mathematical expressions. Currently, this request is needs to be explicitly called with the phrase "Calculate". More flexible options may be added in the future.

Both the Conversions and Calculations blueprints  repeat the request in the response - that is, if the user says "How many Tablespoons are in 5 Cups?", the response is "80 tbsp (tablespoons) is  equivalent to 5 cups", to confirm that the STT processor heard "5 cups" and not "9 cups".