### PR TITLE
Update blueprint-devicecontrol.yaml - fix error when saving w/ no mic…

### DIFF
--- a/View_Assist_control_automations/blueprint-devicecontrol.yaml
+++ b/View_Assist_control_automations/blueprint-devicecontrol.yaml
@@ -329,7 +329,7 @@ action:
       then:
       - service: switch.turn_on
         target:
-          entity_id: !input micdevice
+          entity_id: "{{ micdevice }}"
       - service: python_script.set_state
         data:
           entity_id: '{{ satellite }}'


### PR DESCRIPTION
Use variable micdevice instead of !input micdevice.

This fixes the error preventing the automation from being saved when no mic device is applied in the inputs.