### PR TITLE
Create blueprint-custom_responses.yaml FOR TALKING AVATARS IMPLEMENTA…

### DIFF
--- a/View_Assist_control_automations/blueprint-custom_responses.yaml
+++ b/View_Assist_control_automations/blueprint-custom_responses.yaml
@@ -1,0 +1,62 @@
+blueprint:
+  name: Viewassist Custom Responses
+  description: Automation for custom responses in Viewassist Birou with selectable media content ID, media player, and microphone.
+  domain: automation
+  input:
+    trigger_entity:
+      name: Trigger Entity
+      description: Microphone entity sensor of satellite ex. sensor.viewassist_office_simple_state
+      selector:
+        entity:
+          domain: sensor
+    media_player:
+      name: Media Player
+      description: Select the media player to use
+      selector:
+        entity:
+          domain: media_player
+    microphone_switch:
+      name: Microphone Switch
+      description: Select the microphone switch to turn off and on
+      selector:
+        entity:
+          domain: switch
+    media_content_id:
+      name: Media Content ID
+      description: The media content ID to play (optional, with a default message)
+      default: "media-source://tts/edge_tts?message={{ ['how can I help you', 'yes, i`m listening', 'how can assist you'] | random }}&language=en-US-ChristopherNeural"
+      selector:
+        text: {}
+
+trigger:
+  - platform: state
+    entity_id: !input "trigger_entity"
+    to: wake_word-detected
+
+condition: []
+
+action:
+  - service: switch.turn_off
+    target:
+      entity_id: !input "microphone_switch"
+  - service: media_player.play_media
+    target:
+      entity_id: !input "media_player"
+    data:
+      media_content_id: !input "media_content_id"
+      media_content_type: provider
+      announce: true
+  - wait_for_trigger:
+      - platform: state
+        entity_id: !input "media_player"
+        to: idle
+    timeout:
+      hours: 0
+      minutes: 0
+      seconds: 1
+      milliseconds: 500
+  - service: switch.turn_on
+    target:
+      entity_id: !input "microphone_switch"
+
+mode: single


### PR DESCRIPTION
…TION

Such automation is necessary for using custom responses with ViewAssist and Hassmic integration. Practically, after the wake word is detected, the microphone is paused until the media player finishes playing the message. You can adapt the random messages from Media content ID for any tts service and any language. Copy the template with the random messages and then simulate an automation in which you select the Media Player action and then the desired tts service and a message. Then in the yaml code change the message you put with the random message template where you can change the messages to the ones you want and in whatever language you want.