### PR TITLE
Create blueprint-continue_conversation

### DIFF
--- a/View_Assist_control_automations/blueprint-continue_conversation
+++ b/View_Assist_control_automations/blueprint-continue_conversation
@@ -1,0 +1,68 @@
+blueprint:
+  name: ViewAssist Continue Conversation
+  description: Automation for managing conversation flow in ViewAssist , with customizable entities for sensors and switches.
+  domain: automation
+  input:
+    trigger_sensor:
+      name: Trigger Sensor
+      description: Microphone entity sensor (e.g., sensor.viewassist_office_simple_state)
+      selector:
+        entity:
+          domain: sensor
+    microphone_switch:
+      name: Microphone Switch
+      description: The switch controlling the microphone
+      selector:
+        entity:
+          domain: switch
+    continue_conversation_switch:
+      name: Continue Conversation Switch
+      description: The switch to enable or disable continue conversation
+      selector:
+        entity:
+          domain: switch
+
+trigger:
+  - platform: state
+    entity_id: !input "trigger_sensor"
+    to: intent-processing
+
+condition: []
+
+action:
+  - service: switch.turn_on
+    target:
+      entity_id: !input "continue_conversation_switch"
+  - service: switch.turn_off
+    target:
+      entity_id: !input "microphone_switch"
+  - wait_for_trigger:
+      - platform: state
+        entity_id: !input "trigger_sensor"
+        to: tts-finished
+    timeout:
+      hours: 0
+      minutes: 0
+      seconds: 30
+    continue_on_timeout: true
+  - service: switch.turn_on
+    target:
+      entity_id: !input "microphone_switch"
+  - wait_for_trigger:
+      - platform: state
+        entity_id: !input "trigger_sensor"
+        to: stt-listening
+        for:
+          hours: 0
+          minutes: 0
+          seconds: 5
+    timeout:
+      hours: 0
+      minutes: 0
+      seconds: 20
+    continue_on_timeout: false
+  - service: switch.turn_off
+    target:
+      entity_id: !input "continue_conversation_switch"
+
+mode: single


### PR DESCRIPTION
Such automation is necessary to use the `continue conversation switch` from the Hassmic integration. Basically, when the `Simple state sensor` is set to `intent-processing`, the microphone is muted and the `continue conversation switch` is turned `on`, because immediately after `stt-speech` a new pipeline is started. If at that moment the `continue conversation switch` is on, the pipeline is no longer started from `wake_word-listening` but from `stt-listening`. If no activation of the `intent-processing` status is detected for 5 seconds, the `continue conversation switch` switches to `off` and the next pipeline starts again from `wake_word-listening`. If you use OpenAi integration and want to retain conversation history, you need to add `conversation_id= "123456789"` in this file `/config/custom_components/hassmic/pipeline_manager.py` here
```
    async def _loop(self):
        """Run the managed pipeline."""

        _LOGGER.debug("Starting pipeline manager")

        self._running = True
        self._should_close = False
        while not self._should_close:
            try:                
                start_stage = (
                    PipelineStage.STT
                    if self._hass.data.get("pipeline_start_stage") == PipelineStage.STT
                    else PipelineStage.WAKE_WORD
                )
                await assist_pipeline.async_pipeline_from_audio_stream(
                    hass=self._hass,
                    context=Context(),
                    event_callback=self._event_callback,
                    stt_stream=self._stream,
                    stt_metadata=stt.SpeechMetadata(
                        language="",
                        format=stt.AudioFormats.WAV,
                        codec=stt.AudioCodecs.PCM,
                        bit_rate=stt.AudioBitRates.BITRATE_16,
                        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
                        channel=stt.AudioChannels.CHANNEL_MONO,
                    ),
                    start_stage=start_stage,
                    #start_stage=PipelineStage.WAKE_WORD,
                    device_id=self._device.id,
                    conversation_id= "123456789"
                )
```