### PR TITLE
Add mode change according to musicplayer_device status in blueprint-deviceco…

### DIFF
--- a/View_Assist_control_automations/blueprint-devicecontrol.yaml
+++ b/View_Assist_control_automations/blueprint-devicecontrol.yaml
@@ -329,6 +329,24 @@ trigger:
 - platform: time_pattern
   hours: !input rotate_hour
   id: rotateimage
+- alias: Musicplayer playing
+  id: musicplayer_playing
+  value_template: >
+    {% set ent = state_attr(trigger_satellite, 'musicplayer_device') %} {{ ent is not none and is_state(ent, 'playing') }}
+  trigger: template
+  for:
+    hours: 0
+    minutes: 0
+    seconds: 30
+- alias: Musicplayer not playing
+  id: musicplayer_not_playing
+  value_template: >
+    {% set ent = state_attr(trigger_satellite, 'musicplayer_device') %} {{ ent is not none and not is_state(ent, 'playing') }}
+  trigger: template
+  for:
+    hours: 0
+    minutes: 0
+    seconds: 30
 variables:
   satellite: !input satellite
   group_entity: !input group_entity
@@ -654,4 +672,24 @@ action:
           entity_id: "{{ satellite }}"
           background: "{{ random_image['image_path'] }}"
         action: python_script.set_state
+  - conditions:
+      - condition: trigger
+        id:
+          - musicplayer_playing
+    sequence:
+      - action: python_script.set_state
+        data:
+          entity_id: "{{ satellite }}"
+          mode: music
+          title: ""
+   - conditions:
+      - condition: trigger
+        id:
+          - musicplayer_not_playing
+    sequence:
+      - action: python_script.set_state
+        data:
+          entity_id: "{{ satellite }}"
+          mode: normal
+          title: ""
 mode: parallel


### PR DESCRIPTION
…ntrol.yaml


I found that when the music view is changed, it doesn't go back to the home/clock view after the song is finished playing or if the speaker is turned off. For the `musicplayer_device` I use a different media player than that of the ViewAssist satellite, i.e. google speakers. I think it would be useful to switch the view from the viewassist satellite according to the status of the `musicplayer_device` speaker. Even if I start the playback on the speaker by other methods than the viewassist automations, I think it would be useful for the satellite tablet to see what is playing on the speaker. I've added two triggers `musicplayer_playing` and `musicplayer_not_playing` and two actions to fire the `python_script.set_state` and update the `music mode` or `normal mode`. Please look into whether this functionality is implemented somewhere and give me an answer.