### PR TITLE
Add playmusicwithspotcast custom sentence

### DIFF
--- a/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/README.md
+++ b/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/README.md
@@ -1,0 +1,144 @@
+# View Assist - Play Music with Spotcast
+
+This project provides a pair of Home Assistant blueprints that use the [SpotcastV5](https://github.com/fondberg/spotcast/tree/dev) and [ViewAssist](https://github.com/dinki/view_assist_integration) integrations to control Spotify music playback with natural language commands and expose it to LLMs as a tool with a script.
+
+The blueprints include:
+
+- **Automation Blueprint:**  
+  Enables music playback in multiple modes:
+  - **Play DJ (Recently Played):** Plays your recently played songs.
+  - **Play Search (Music Search):** Plays music based on search keywords (e.g., album, artist, playlist, or track name).
+  - **Transfer Playback:** Allows you to move the active playback from one area to another. When a specific area is provided, the music plays on that media player, and the corresponding display (satellite) updates accordingly.
+
+- **Script Blueprint:**  
+  Creates a script that constructs and sends a natural language command to the Home Assistant conversation agent via the `conversation.process` service. This script dynamically builds the voice command based on the following parameters:
+  - `music_type`: Defines the type of request—`recent`, `search`, or `transfer`.
+  - `music_query`: The query used when searching for a specific song, artist, or genre (required for search requests).
+  - `area`: The target area where the music should play or be transferred.
+
+---
+
+## Features
+
+- **No premium Spotify account needed**  
+  Works with both premium and non-premium Spotify accounts.
+
+- **Playback Modes:**
+  - **DJ Mode:**  
+    Plays music using the context of your recently played songs.
+  - **Search Mode:**  
+    Plays music based on search keywords provided by the user.
+  - **Transfer Mode:**  
+    Moves the current playback to a specified area/media player.
+
+- **Zone-Based Control:**  
+  When an area is specified (using the `{area}` variable), the automation directs playback to the media player named in the format `media_player.<area>_speaker`. If no area is provided, it defaults to the last active media player or default one on the associated satellite.
+
+- **LLM Integration:**  
+  The script blueprint exposes the functionality to language model integrations (LLMs) or Home Assistant's built-in conversation agent. **Important:** Do not modify or remove the default English trigger phrases in the automation blueprint. Additional phrases can be added following the same structure.
+
+---
+
+## Prerequisites
+
+- **Home Assistant:**  
+  Ensure you are running `min_version: "2024.10.0"` of Home Assistant.
+
+- **Integrations:**
+  - [SpotcastV5](https://github.com/fondberg/spotcast/tree/dev)
+  - [ViewAssist](https://github.com/dinki/view_assist_integration)
+
+- **Entity Naming Convention:**  
+  Your media player entity IDs must follow the format:  
+  `media_player.<area>_speaker`  
+  where `<area>` corresponds to the room or zone where the speaker is located.
+
+---
+
+## Installation
+
+### 1. Automation Blueprint
+
+#### Method A: Auto-Installation Button
+
+Click the button below to open Home Assistant and import the automation blueprint directly:
+
+[![Open in Home Assistant](https://my.home-assistant.io/images/open-in-ha-blue.svg)](https://my.home-assistant.io/redirect/blueprint/?url=https://raw.githubusercontent.com/dinki/View-Assist/main/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-playmusicwithspotcast-automation.yaml)
+
+#### Method B: Manual Installation
+
+1. Download the file [`blueprint-playmusicwithspotcast-automation.yaml`](https://raw.githubusercontent.com/dinki/View-Assist/main/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-playmusicwithspotcast-automation.yaml).
+2. Place it in the following directory on your Home Assistant configuration: `/config/blueprints/automation/relu/blueprint-vacc-playmusicwithspotcast-automation.yaml`
+3. In Home Assistant, create a new automation from blueprint and fill in the required inputs:
+- **Group Entity:** The group containing your ViewAssist satellites (e.g., `group.viewassist_satellites`).
+- **Dashboard Info View:** The path to your ViewAssist dashboard (e.g., `/dashboard-viewassist/music`).
+- **Display Navigation App:** The service used for navigating the display (e.g., `remote_assist_display.navigate`).
+
+---
+
+### 2. Script Blueprint
+
+#### Method A: Auto-Installation Button
+
+Click the button below to open Home Assistant and import the script blueprint directly:
+
+[![Open in Home Assistant](https://my.home-assistant.io/images/open-in-ha-blue.svg)](https://my.home-assistant.io/redirect/blueprint/?url=https://raw.githubusercontent.com/dinki/View-Assist/main/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast%20-%20LLMscript.yaml)
+
+#### Method B: Manual Installation
+
+1. Download the file [`blueprint-vacc-playmusicwithspotcast - LLMscript.yaml`](https://raw.githubusercontent.com/dinki/View-Assist/main/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast%20-%20LLMscript.yaml).
+2. Place it in the following directory on your Home Assistant configuration: `/config/blueprints/script/relu/blueprint-vacc-playmusicwithspotcast-LLMscript.yaml`
+
+**Note:** Verify that the file name does not contain any unwanted spaces or special characters.
+
+3. After installation, ensure the script is exposed to the Home Assistant conversation agent so it can be triggered via voice commands.
+
+---
+
+## How to Use
+
+1. **Voice Commands & Triggers:**  
+The automation blueprint comes with a set of default trigger phrases:
+- **Play DJ Mode:**  
+  Examples:  
+  - "I want to play my recent music"  
+  - "I want to play my recent songs on {area} speaker"
+- **Play Search Mode:**  
+  Examples:  
+  - "play {music}"  
+  - "play {music} on {area} speaker"
+- **Transfer Music:**  
+  Examples:  
+  - "move the music on {area} speaker"  
+  - "transfer the music on {area} speaker"
+
+**Important:** Do not modify or remove the default trigger phrases if you plan to use the LLM integration. Additional phrases in another languages can be added following the same structure.
+
+2. **Action Flow:**  
+Depending on the command received, the blueprint will:
+- Call the appropriate Spotcast service (`spotcast.play_dj`, `spotcast.play_from_search`, or `spotcast.transfer_playback`).
+- Update the corresponding ViewAssist satellite display to reflect the active media player.
+- Set the state of the satellite device to indicate that music is playing.
+
+3. **Script Execution:**  
+The script blueprint constructs a command string based on the provided inputs (`music_type`, `music_query`, and `area`) and sends it via the `conversation.process` service. This allows for natural language interaction with your Home Assistant setup.
+
+4. **Customization:**  
+You can customize the default responses and trigger phrases to better suit your language or personal preferences. Just ensure that any changes maintain the overall structure required for LLM integrations.
+
+---
+
+## Resources & Documentation
+
+- **Spotify:** [https://open.spotify.com/](https://open.spotify.com/)
+- **SpotcastV5 on GitHub:** [https://github.com/fondberg/spotcast/tree/dev](https://github.com/fondberg/spotcast/tree/dev)
+- **ViewAssist on GitHub:** [https://github.com/dinki/view_assist_integration](https://github.com/dinki/view_assist_integration)
+- **Home Assistant Blueprints Documentation:** [Home Assistant Blueprints](https://www.home-assistant.io/docs/automation/blueprint/)
+
+---
+
+
+
+
+
+

--- a/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/README.md
+++ b/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/README.md
@@ -47,6 +47,7 @@ The blueprints include:
 - **Integrations:**
   - [SpotcastV5](https://github.com/fondberg/spotcast/tree/dev)
   - [ViewAssist](https://github.com/dinki/view_assist_integration)
+  - [ViewAssist- Music view](https://github.com/dinki/View-Assist/blob/main/View%20Assist%20dashboard%20and%20views/views/music/music.yaml)
 
 - **Entity Naming Convention:**  
   Your media player entity IDs must follow the format:  

--- a/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast - LLMscript.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast - LLMscript.yaml
@@ -1,0 +1,79 @@
+blueprint:
+  name: "View Assist - Play Music with Spotcast - Script"
+  description: |
+
+    # Creates a script which will allow voice requests for Spotcast music playback
+
+    * No changes are required for any of the settings below for this script to work, but
+    your specific LLM integration may need some fine-tuning. To do that, adjust the
+    prompts sent to the LLM.
+    * **Important Requirements:**
+        * You must install the **ViewAssist playmusicwithspotcast** automation.
+        * **DO NOT CHANGE OR REMOVE THE DEFAULT ENGLISH TRIGGER SENTENCES OF AUTOMATION**.
+        * You can make other trigger sentences in automation alongside the default ones in English or another language keeping the structure of the default ones.
+        * You must install the **[SpotcastV5](https://github.com/fondberg/spotcast/tree/dev)** integration.
+
+    * **Make sure to expose the script to Assist after creating it.**  
+
+    * **Make sure to give the script a clear description.** An example can be found below.  
+
+    * It is possible to add additional actions to be performed after the Spotcast
+    play media action. There are several variables available which are described below.  
+
+    ## Example for script description
+
+    `This script controls music playback using natural language commands.
+    It works by constructing a voice command and sending it to the Home Assistant conversation agent
+    via the \`conversation.process\` action. This allows an LLM or Home Assistant to control music playback
+    in different areas of the home.
+
+    The tool takes the following arguments: \`music_type\`, \`music_query\`, and \`area\`.  
+    - \`music_type\` is required and must be one of: "recent", "search", or "transfer".  
+    - \`music_query\` is required for "search" and should contain the song, artist, or genre.  
+    - \`area\` is optional and defines where to play or move the music.  
+
+    Use this tool whenever the user requests to play or transfer music.`
+
+    ## On LLM prompt you can add a description like this adapted to name of your script
+
+    For play music use `script.view_assist_play_music_with_spotcast_script`
+
+    ## Available variables for additional actions
+
+    |Variable|Description|
+    |---|---|
+    |`music_type`|Defines the type of request: `"recent"` (play recent music), `"search"` (search for specific music), or `"transfer"` (move playback to another area).|
+    |`music_query`|The specific music query when `music_type` is "search". Could be a song, artist, or genre.|
+    |`area`|The area(s) where music should be played or transferred. If not defined, the last used area is used.|
+    |`music_request`|The final generated command text that is passed to `conversation.process`. It is dynamically structured based on the inputs.|
+
+    '
+  domain: script
+  input: {}
+
+alias: "View Assist - Play Music with Spotcast - script"
+mode: parallel
+icon: mdi:music
+max_exceeded: silent
+
+sequence:
+  - variables:
+      music_type: "{{ music_type | default('') }}"
+      music_query: "{{ music_query | default('') }}"
+      area: "{{ area | default('') }}"
+      music_request: >-
+        {% if area and music_type == 'recent' %}
+          I want to play music on {{ area }}
+        {% elif area and music_type == 'search' %}
+          play {{ music_query }} on {{ area }}
+        {% elif area and music_type == 'transfer' %}
+          move on {{ area }}
+        {% elif music_type == 'recent' %}
+          I want to play music
+        {% elif music_type == 'search' %}
+          play {{ music_query }}
+        {% endif %}
+  - action: conversation.process
+    data:
+      text: "{{ music_request }}"
+      agent_id: conversation.home_assistant

--- a/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast-automation.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC-PLAY-MUSIC-WITH-SPOTCAST/blueprint-vacc-playmusicwithspotcast-automation.yaml
@@ -1,0 +1,307 @@
+blueprint:
+  name: View Assist - Play Music with Spotcast
+  description: |
+    This automation is designed to be used with the [ViewAssist](https://github.com/dinki/view_assist_integration) integration for playing music from Spotify using the [SpotcastV5](https://github.com/fondberg/spotcast/tree/dev) integration.
+
+    It supports both premium and non-premium Spotify accounts.
+
+    **Features:**
+    - Plays music from Spotify using the context of your recently played songs (Play DJ mode).
+    - Plays music from Spotify based on search keywords (Play Search mode). Searches can be performed using album, artist, playlist, or track names.
+    - Plays music in a specified area. When an area is defined, the music is played on that specific media player, and the tablet from which the command is issued will display the player currently in use—even if it is not the default for that satellite. For this, musicplayer_device is overwritten in the sensor of the respective ViewAssist satellite.
+    - If no area is specified, it uses the last active media player on that satellite.
+    - Transfers playback from one player to another, continuing from where it left off. The display on the satellite from which the command is issued will show the active player if it has been changed via voice commands.
+    - The default trigger phrases and conversation responses can be translated into any language as long as their structure is maintained.
+    - **IMPORTANT:** If you wish to expose this automation as a tool for LLMs using a script, do not remove or modify the default trigger phrases. Instead, add additional phrases following the same model and structure in the same window, since the LLM exposure script will call this automation using the default trigger phrases via the `Conversation.process` service.
+    - **IMPORTANT:** Entity ID from media players must be of the form `media_player.area_speaker`, **area** being the room or area where the speaker is located.
+
+  domain: automation
+  # (Optional: add min_version: "2024.10.0" if needed)
+  input:
+    group_entity:
+      name: Group Entity
+      description: The group containing the list of View Assist satellites (e.g., group.viewassist_satellites)
+      selector:
+        entity:
+          filter:
+            - domain: group
+          multiple: false
+      default: group.viewassist_satellites
+    view_path:
+      name: Dashboard Info View
+      description: The View Assist dashboard view used to display music information (e.g., /dashboard-viewassist/music)
+      default: /dashboard-viewassist/music
+    navigation_app:
+      name: Display Navigation App
+      description: Choose the service used to navigate the display.
+      selector:
+        select:
+          options:
+            - browser_mod.navigate
+            - remote_assist_display.navigate
+      default: remote_assist_display.navigate
+
+    # Input for trigger phrases with default values (customizable as needed)
+
+    # Trigger phrases for Play DJ (Recently Played) mode.
+    # This mode calls Spotify to play songs based on your recently played tracks.
+    # If an area is specified using {area}, the music plays on that specific media player;
+    # if omitted, the default or last active media player is used.
+    trigger_play_dj:
+      name: Trigger Phrases for Play DJ (Recently Played)
+      description: List of phrases to invoke Play DJ mode. Use '{area}' to specify a media player area. If omitted, the default/last active media player is used.
+      default:
+        - "I want to play [my] [recent] ( music|songs) (on|in|to) [the] {area} [speaker]"
+        - "I want to play [my] [recent] (music|songs)"
+      selector:
+        object: {}
+
+    # Trigger phrases for Play Search (Music Search) mode.
+    # This mode asks Spotify to play music based on search keywords such as artist, song, album, or genre.
+    # If an area is specified using {area}, the music plays on that specific media player;
+    # if omitted, the default or last active media player is used.
+    trigger_play_search:
+      name: Trigger Phrases for Play Search (Music Search)
+      description: List of phrases to invoke Play Search mode. Use '{area}' to specify a media player area. If omitted, the default/last active media player is used.
+      default:
+        - "play  {music} (on|in|to) [the] {area} [speaker]"
+        - "play {music}"
+      selector:
+        object: {}
+
+    # Trigger phrases for transferring music playback to a specific area.
+    # Use these phrases to move the current playback to a designated media player area.
+    trigger_transfer_music:
+      name: Trigger Phrases for Transfer Music
+      description: List of phrases to transfer music playback to a specified area. Use '{area}' to indicate the target media player.
+      default:
+        - "move [the] [music] [song] (on|in|to) [the] {area} [speaker]"
+        - "transfer [the] [music] [song] (on|in|to) [the] {area} [speaker]"
+      selector:
+        object: {}
+
+    # Input for conversation responses with default values (customizable as needed)
+
+    # Response text for Play DJ mode when no area is specified.
+    response_play_dj_no_area:
+      name: Response for Play DJ (No Area)
+      description: Response text when invoking Play DJ mode without specifying an area.
+      default: "Playing your recent played songs"
+      selector:
+        text: {}
+
+    # Response text for Play DJ mode when an area is specified.
+    response_play_dj_area:
+      name: Response for Play DJ (With Area)
+      description: Response text when invoking Play DJ mode with a specified area.
+      default: "Playing your recent played songs to the {{ trigger.slots.area }}"
+      selector:
+        text: {}
+
+    # Response text for Play Search mode when no area is specified.
+    response_play_search_no_area:
+      name: Response for Play Search (No Area)
+      description: Response text when invoking Play Search mode without specifying an area.
+      default: "Playing {{ trigger.slots.music }}"
+      selector:
+        text: {}
+
+    # Response text for Play Search mode when an area is specified.
+    response_play_search_area:
+      name: Response for Play Search (With Area)
+      description: Response text when invoking Play Search mode with a specified area.
+      default: "Playing {{ trigger.slots.music }} in the {{ trigger.slots.area }}"
+      selector:
+        text: {}
+
+    # Response text for transferring music playback.
+    response_transfer_music:
+      name: Response for Transfer Music
+      description: Response text when transferring music playback to a specified area.
+      default: "I moved the music to {{ trigger.slots.area }}"
+      selector:
+        text: {}
+
+triggers:
+  - trigger: conversation
+    command: !input trigger_play_dj
+    id: play_dj
+    enabled: true
+  - trigger: conversation
+    command: !input trigger_play_search
+    id: play_search
+    enabled: true
+  - trigger: conversation
+    command: !input trigger_transfer_music
+    id: transfer_music
+
+conditions: []
+actions:
+  - choose:
+      # Condition for executing Play DJ without area specified (i.e., using the default or last active media player)
+      - conditions:
+          - condition: template
+            alias: "Condition for executing Play DJ without area specified"
+            value_template: "{{ trigger.id == 'play_dj' and (trigger.slots.area is not defined or trigger.slots.area == '') }}"
+        sequence:
+          - action: spotcast.play_dj
+            alias: "Play DJ without area specified"
+            data:
+              media_player:
+                device_id: "{{ target_musicplayer_device }}"
+          - action: "{{ navigation_app }}"
+            alias: "Navigate to music dashboard"
+            data:
+              path: "{{ view_path }}"
+            target:
+              device_id: "{{ target_display_device }}"
+          - action: python_script.set_state
+            alias: "Set satellite device state to music mode"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: music
+              title: ""
+          - set_conversation_response: !input response_play_dj_no_area
+
+      # Condition for executing Play DJ with a specified area
+      - conditions:
+          - condition: template
+            alias: "Condition for executing Play DJ with specified area"
+            value_template: "{{ trigger.id == 'play_dj' and trigger.slots.area is defined and trigger.slots.area != '' }}"
+        sequence:
+          - action: spotcast.play_dj
+            alias: "Play DJ in specified area"
+            data:
+              media_player:
+                entity_id: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+          - action: python_script.set_state
+            alias: "Set satellite device state to music mode for specified area"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: music
+              title: ""
+          - action: python_script.set_state
+            alias: "Set satellite device music player for specified area"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              musicplayer_device: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+              title: ""
+          - set_conversation_response: !input response_play_dj_area
+
+      # Condition for executing Play Search without area specified (i.e., using the default or last active media player)
+      - conditions:
+          - condition: template
+            alias: "Condition for executing Play Search without area specified"
+            value_template: "{{ trigger.id == 'play_search' and (trigger.slots.area is not defined or trigger.slots.area == '') }}"
+        sequence:
+          - action: spotcast.play_from_search
+            alias: "Play searched music without area specified"
+            data:
+              item_types:
+                - album
+                - artist
+                - playlist
+                - track
+              media_player:
+                device_id: "{{ target_musicplayer_device }}"
+              search_term: "{{ trigger.slots.music }}"
+          - action: "{{ navigation_app }}"
+            alias: "Navigate to music dashboard"
+            data:
+              path: "{{ view_path }}"
+            target:
+              device_id: "{{ target_display_device }}"
+          - action: python_script.set_state
+            alias: "Set satellite device state to music mode for search without area"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: music
+              title: ""
+          - set_conversation_response: !input response_play_search_no_area
+
+      # Condition for executing Play Search with a specified area
+      - conditions:
+          - condition: template
+            alias: "Condition for executing Play Search with specified area"
+            value_template: "{{ trigger.id == 'play_search' and trigger.slots.area is defined and trigger.slots.area != '' }}"
+        sequence:
+          - action: spotcast.play_from_search
+            alias: "Play searched music in specified area"
+            data:
+              item_types:
+                - album
+                - artist
+                - playlist
+                - track
+              media_player:
+                entity_id: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+              search_term: "{{ trigger.slots.music }}"
+          - action: "{{ navigation_app }}"
+            alias: "Navigate to music dashboard"
+            data:
+              path: "{{ view_path }}"
+            target:
+              device_id: "{{ target_display_device }}"
+          - action: python_script.set_state
+            alias: "Set satellite device state to music mode for search with area"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: music
+              title: ""
+          - action: python_script.set_state
+            alias: "Set satellite device music player for search with specified area"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              musicplayer_device: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+              title: ""
+          - set_conversation_response: !input response_play_search_area
+
+      # Condition for transferring music playback to a specified area
+      - conditions:
+          - condition: template
+            alias: "Condition for transferring music playback to specified area"
+            value_template: "{{ trigger.id == 'transfer_music' }}"
+        sequence:
+          - action: spotcast.transfer_playback
+            alias: "Transfer playback to specified area"
+            data:
+              media_player:
+                entity_id: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+          - action: python_script.set_state
+            alias: "Set satellite device state to music mode for transfer"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              mode: music
+              title: ""
+          - action: python_script.set_state
+            alias: "Set satellite device music player for transfer"
+            data:
+              entity_id: "{{ target_satellite_device }}"
+              musicplayer_device: "media_player.{{ trigger.slots.area | replace('ă', 'a') |
+                  replace('î', 'i') | replace('ș', 's') | replace('ț', 't') |
+                  lower }}_speaker"
+              title: ""
+          - set_conversation_response: !input response_transfer_music
+mode: single
+variables:
+  view_path: !input view_path
+  group_entity: !input group_entity
+  navigation_app: !input navigation_app
+  target_satellite_device: >-
+    {% for sat in expand(group_entity) %}
+      {% if (device_id(sat.attributes.mic_device) == trigger.device_id) or (device_id(sat.attributes.display_device) == trigger.device_id) %}
+        {{ sat.entity_id }}
+      {% endif %}
+    {% endfor %}
+  target_display_device: "{{ device_id(state_attr(target_satellite_device, 'display_device')) }}"
+  target_musicplayer_device: "{{ device_id(state_attr(target_satellite_device, 'musicplayer_device')) }}"


### PR DESCRIPTION
## Add Spotcast Support to View Assist  

Hey! 😊 This PR adds a **Custom Sentence** to let View Assist play music from **Spotify** using **Spotcast**.  

### What’s new?  
- Supports **Spotify Free** accounts (no Premium needed).  
- Lets users start music playback via voice commands with View Assist satellites.  
- Automatically casts to a selected Chromecast if needed.  

Basically, this makes it easy to play Spotify through View Assist without requiring Premium. Let me know if anything needs tweaking! 🚀  
