### PR TITLE
Extended device control update STT input description and fix auto music mode on/off

### DIFF
--- a/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
@@ -380,15 +380,16 @@ actions:
             attribute: mode
             state: normal
         sequence:
-          - action: browser_mod.navigate
-            data:
-              path: "{{ music }}"
-            target:
-              device_id: "{{ state_attr(display, 'browserID') }}"
-          - action: python_script.set_state
-            data:
-              entity_id: !input satellite
-              mode: music
+          - parallel:
+              - action: browser_mod.navigate
+                data:
+                  path: "{{ music }}"
+                target:
+                  device_id: "{{ state_attr(display, 'browserID') }}"
+              - action: python_script.set_state
+                data:
+                  entity_id: !input satellite
+                  mode: music
       - conditions:
           - condition: trigger
             id:
@@ -400,15 +401,16 @@ actions:
             attribute: mode
             state: music
         sequence:
-          - action: browser_mod.navigate
-            data:
-              path: "{{ home }}"
-            target:
-              device_id: "{{ state_attr(display, 'browserID') }}"
-          - action: python_script.set_state
-            data:
-              entity_id: !input satellite
-              mode: normal
+          - parallel:
+              - action: browser_mod.navigate
+                data:
+                  path: "{{ home }}"
+                target:
+                  device_id: "{{ state_attr(display, 'browserID') }}"
+              - action: python_script.set_state
+                data:
+                  entity_id: !input satellite
+                  mode: normal
       - conditions:
           - condition: or
             conditions:

--- a/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
@@ -82,7 +82,7 @@ blueprint:
           default:
         stt_sensor:
           name: STT Sensor
-          description: The STT sensor for the above View Assist device (e.g. sensor.viewassist_living_room_stt)
+          description: The STT sensor for the above View Assist device (e.g. sensor.viewassist_living_room_stt or sensor.hassmic_living_room_simple_state)
           selector:
             entity:
               filter:

--- a/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
@@ -384,7 +384,7 @@ actions:
             data:
               path: "{{ music }}"
             target:
-              device_id: "{{device_id(display)}}"
+              device_id: "{{ state_attr(display, 'browserID') }}"
           - action: python_script.set_state
             data:
               entity_id: !input satellite
@@ -404,7 +404,7 @@ actions:
             data:
               path: "{{ home }}"
             target:
-              device_id: "{{device_id(display)}}"
+              device_id: "{{ state_attr(display, 'browserID') }}"
           - action: python_script.set_state
             data:
               entity_id: !input satellite

--- a/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
+++ b/View_Assist_custom_sentences/community_contributions/VACC_Extended_Device_Control-Display_and_Audio/blueprint-vacc-extendeddevicecontrol.yaml
@@ -21,7 +21,7 @@ blueprint:
     yaml file.__
 
     (View Assist Community Contributions - Extended Device Control - Display & Audio
-    v 1.1.0)"
+    v 1.1.1)"
   domain: automation
   source_url: https://gist.github.com/Flight-Lab/6ddb640f756791d59b6fd9be93375eee
   author: Flab

--- a/wiki/docs/community-contributions/cc-sentences/extended-device-controls.md
+++ b/wiki/docs/community-contributions/cc-sentences/extended-device-controls.md
@@ -129,6 +129,7 @@ soundplayer_device
 
 | Version | Description |
 | ------- | ----------- |
+| v 1.1.1 | Music mode auto on/off fix |
 | v 1.1.0 | Further HassMic Support & input adjustments |
 | v 1.0.3 | Initial HassMic Support & pause option instead of ducking |
 | v 1.0.2 | Updates to blueprint inputs & descriptions |


### PR DESCRIPTION
Input description to include hassmic example.

Fix the broken template in auto music mode on/off.

Music mode on/off now runs navigate and set state actions in parallel.

Bump version to 1.1.1