### PR TITLE
Fix popup UI effects for pre-wyoming HassMic devices

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -12,20 +12,28 @@ button_card_templates:
             var assist_assistbid = localStorage.getItem("view_assist_sensor");
             var micdevice = hass.states[assist_assistbid].attributes.mic_device;
             var micstate = hass.states[micdevice].state;
+            var assisting = false;
+            
             if (micdevice.includes("_stt")) 
             {
-              var assisting = micstate.includes("start") || micstate.includes("vad")
+              assisting = micstate.includes("start") || micstate.includes("vad");
             }
             else if (micdevice.includes("assist_satellite"))
             {
-              var assist_in_progress_sensor =  micdevice
-              var assist_in_progress = hass.states[assist_in_progress_sensor].state
+              var assist_in_progress_sensor = micdevice;
+              var assist_in_progress = hass.states[assist_in_progress_sensor].state;
               if (assist_in_progress === "listening" || assist_in_progress === "processing") {
                   assisting = true; 
-              } else {
-                  assisting = false;
               }              
             }
+            else
+            {
+              // HassMic detection from older version
+              assisting = micstate.includes("stt-listening") || 
+                         micstate.includes("intent-processing") || 
+                         micstate.includes("tts-speaking");
+            }
+            
             return `${assisting}`;
           } catch { return  ""}
         ]]]


### PR DESCRIPTION
This PR fixes issues with the blur popup and other UI effects not working properly with older versions of HassMic.
Problem
The template logic in dashboard.yaml only checked for specific states with Stream Assist and HA Voice Satellite devices, but lacked proper detection for HassMic states.
Solution
Updated the var_assisting template to properly detect HassMic active states:

- Added detection for "stt-listening", "intent-processing", and "tts-speaking" states.
- Maintained compatibility with other microphone types.
- Restored functionality that existed in older versions.