### PR TITLE
Update locate view to support multilanguage

### DIFF
--- a/View Assist dashboard and views/views/locate/locate.yaml
+++ b/View Assist dashboard and views/views/locate/locate.yaml
@@ -95,27 +95,50 @@ custom_fields:
             return `${var_location_text}`}
           catch { return ""}]]]           
         updated: |-
-          [[[ try {
-            var var_tracker = hass.states[variables.var_assistsat_entity].attributes.locate_data.person;                  
-            var var_last_changed = new Date(hass.states[var_tracker].last_changed);
-            const current_date = new Date();
-            const diff = current_date - var_last_changed;
-            const minutes = Math.floor(diff / (1000 * 60));
-            const hours = Math.floor(diff / (1000 * 60 * 60));
-            const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-            const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
-            let last_changed;
-            if (minutes < 1) {
-              last_changed = "now";          
-            } else if (minutes < 60) {                    
-              last_changed = rtf.format(-minutes, 'minute');  // e.g., "5 minutes ago"
-            } else if (hours < 24) {
-              last_changed = rtf.format(-hours, 'hour');  // e.g., "2 hours ago"
-            } else {
-              last_changed = rtf.format(-days, 'day');  // e.g., "3 days ago"
+          [[[ 
+            try {
+              // 1) Get the HA / browser locale
+              const localeRaw = hass.selectedLanguage 
+                               || hass.language 
+                               || hass.config.language 
+                               || navigator.language;
+              // e.g. "it-IT" -> "it"
+              const lang = localeRaw.split(/[-_]/)[0];
+        
+              // 2) Translation dictionary for the prefix
+              const prefixes = {
+                en: "Last updated",
+                it: "Ultimo aggiornamento",
+                de: "Zuletzt aktualisiert",
+                es: "Última actualización",
+                fr: "Dernière mise à jour",
+                // … add here more languages
+              };
+              const prefix = prefixes[lang] || prefixes.en;
+        
+              // 3) Calculate the elapsed time since last change
+              const tracker = hass.states[variables.var_assistsat_entity]
+                                  .attributes.locate_data.person;
+              const lastChanged = new Date(hass.states[tracker].last_changed);
+              const now = new Date();
+              const diff = now - lastChanged;
+              const minutes = Math.floor(diff / 60000);
+              const hours   = Math.floor(diff / 3600000);
+              const days    = Math.floor(diff / 86400000);
+        
+              // 4) Format using Intl.RelativeTimeFormat
+              const rtf = new Intl.RelativeTimeFormat(localeRaw, { numeric: 'auto' });
+              let rel;
+              if (minutes < 1)       rel = rtf.format(0,      'minute');  // "now" or localized equivalent
+              else if (minutes < 60) rel = rtf.format(-minutes, 'minute');
+              else if (hours < 24)   rel = rtf.format(-hours,   'hour');
+              else                   rel = rtf.format(-days,    'day');
+        
+              return `${prefix}: ${rel}`;
+            } catch {
+              return "";
             }
-            return `${"last changed "+last_changed}`}
-          catch { return ""}]]]          
+          ]]]          
       show_icon: false
       show_name: false
       styles:


### PR DESCRIPTION
This change introduces automatic detection of the Home Assistant user's preferred language via 'hass.selectedLanguage', 'hass.language', or 'hass.config.language' (with a fallback to 'navigator.language') and applies an appropriate translation for the "Last updated" prefix. It uses 'Intl.RelativeTimeFormat' to render relative time strings (e.g. "3 ore fa", "2 days ago") in the appropriate locale, providing seamless multilingual support without manual intervention.