### PR TITLE
Update m5stack-atom-echo.yaml fix for framework version

### DIFF
--- a/wiki/docs/supported-devices/esphome-devices/m5stack-atom-echo.yaml
+++ b/wiki/docs/supported-devices/esphome-devices/m5stack-atom-echo.yaml
@@ -15,6 +15,9 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
+    sdkconfig_options: {}
+    version: 4.4.8
+    platform_version: 5.4.0
 
 logger:
 api:


### PR DESCRIPTION
Added quick fix to pin the framework version due to the lighting control used in this config and the updated features for new framework version don't quite work yet but pinning the version allows the config to work on the current version of ESPHome