### PR TITLE
Always filter current view icon from status bar

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -350,7 +350,7 @@ button_card_templates:
                     function addIconToList(icon, isDynamicItem = false) {
                       if (icon === "menu") return;
 
-                      if (menuActive && isCurrentView(icon)) {
+                      if (isCurrentView(icon)) {
                         return;
                       }
 


### PR DESCRIPTION
Modified icon list generation to hide the current view's icon from the status bar, preventing redundant navigation options. Previously, the current view icon only hid when menu was active, this resulted in the feature only working with menu icons, now it's always filtered regardless of menu state or placement.