### PR TITLE
Add template validation for status icons

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -446,7 +446,7 @@ button_card_templates:
                         template: "menu"
                       });
                     }
-                  } catch (error) {
+                  } catch (e) {
                   }
 
                   return buttonList;


### PR DESCRIPTION
## Description
Prevents button-card errors when users add custom status icons without corresponding templates in dashboard.yaml. Instead of cryptic errors, displays a user-friendly orange warning indicator showing which template is missing.

## Changes
- Query lovelace config to detect available button-card templates
- Validate static icon templates before rendering
- Show orange alert icon with dashed border for missing templates
- Dynamic icons (view:, entity:, service:) unaffected - always use core templates
- Graceful fallback if template detection unavailable
