### PR TITLE
Add first draft of Avatar_Prompt_Responses.md

### DIFF
--- a/wiki/docs/community-contributions/cc-sentences/avatar_prompt_responses.md
+++ b/wiki/docs/community-contributions/cc-sentences/avatar_prompt_responses.md
@@ -71,7 +71,7 @@ and select the avatar you’ve activated.
 ### Step 3 — Install and set up the Blueprint
 
 Import and install the blueprint:  
-👉 [Custom Prompt Responses](https://github.com/dinki/View-Assist/tree/dev/View_Assist_custom_sentences/community_contributions/Custom_Promt_Responses)
+👉 [Custom Prompt Responses](https://github.com/dinki/View-Assist/tree/dev/View_Assist_custom_sentences/community_contributions/Custom_Prompt_Responses)
 
 Then, configure the fields as follows:
 


### PR DESCRIPTION
This PR adds the first draft of the Avatar_Promt_Responses tutorial. 

It covers how to:
- Copy overlay files (overlay.html, overlay.css, and avatar GIFs) to /config/view_assist/custom_overlays
- Configure avatars in View Assist Integration
- Install and set up the Custom Prompt Responses blueprint
- Set up TTS URL templates
- Synchronize microphone with greeting messages

⚠️ Note: Some links and references may need updating once related components are merged from dev to main.

I’m sharing the raw material as-is. Since the team knows best how these features should be implemented, feel free to refine the tutorial or finalize the setup. My goal is simply to help get this feature launched in an easy-to-use way for anyone.