### PR TITLE
Refactor(dashboard): Simplify var_current_view by removing unnecessary fallback

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -191,22 +191,11 @@ button_card_templates:
         [[[
           try {
             const pathname = window.location.pathname;
-            if (pathname) {
-              const match = pathname.match(/\/view-assist\/([^\/]+)/);
-              if (match && match[1]) {
-                return match[1];
-              }
-            }
-
-            const currentPath = hass.states[variables.var_assistsat_entity].attributes.current_path;
-            if (currentPath) {
-              const match = currentPath.match(/\/view-assist\/([^\/]+)/);
-              if (match && match[1]) {
-                return match[1];
-              }
-            }
-            return "";
-          } catch { return ""; }
+            const match = pathname.match(/\/view-assist\/([^\/]+)/);
+            return match && match[1] ? match[1] : "";
+          } catch { 
+            return ""; 
+          }
         ]]]
   body_template:
     show_state: false


### PR DESCRIPTION
Removes the current_path attribute fallback from var_current_view since window.location.pathname is always available in browser context and will always match when the View Assist dashboard is active.