### PR TITLE
fix(dashboard): prevent content overflow when header is visible

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -283,8 +283,18 @@ button_card_templates:
         - grid-template-columns: 1fr 1fr
         - row-gap: .5rem
       card:
-        - min-height: 100vh
-        - max-height: 100vh
+        - min-height: |-
+            [[[
+              return 'calc(100vh - var(--header-height, 0px))';
+            ]]]
+        - max-height: |-
+            [[[
+              return 'calc(100vh - var(--header-height, 0px))';
+            ]]]
+        - height: |-
+            [[[
+              return 'calc(100vh - var(--header-height, 0px))';
+            ]]]
         - aspect-ratio: |-
             [[[
               if (!window.viewAssistResponsive) return "16 / 9";
@@ -311,7 +321,6 @@ button_card_templates:
             ]]]
         - font-weight: 300
         - position: relative
-        - height: 100vh
         - box-sizing: border-box
       custom_fields:
         title:


### PR DESCRIPTION
Adjusts viewport height calculations in body_template to account for Home Assistant header when visible.