### PR TITLE
Revert "Merge pull request #294 from Flight-Lab/dashboard-overflow"

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -291,18 +291,8 @@ button_card_templates:
         - grid-template-columns: 1fr 1fr
         - row-gap: .5rem
       card:
-        - min-height: |-
-            [[[
-              return 'calc(100vh - var(--header-height, 0px))';
-            ]]]
-        - max-height: |-
-            [[[
-              return 'calc(100vh - var(--header-height, 0px))';
-            ]]]
-        - height: |-
-            [[[
-              return 'calc(100vh - var(--header-height, 0px))';
-            ]]]
+        - min-height: 100vh
+        - max-height: 100vh
         - aspect-ratio: |-
             [[[
               if (!window.viewAssistResponsive) return "16 / 9";
@@ -329,6 +319,7 @@ button_card_templates:
             ]]]
         - font-weight: 300
         - position: relative
+        - height: 100vh
         - box-sizing: border-box
       custom_fields:
         title:


### PR DESCRIPTION
This reverts commit d3f68719a578a73223611a58084f18e8a5224cd7, reversing changes made to 2cfed21b2bc5abbfcca05d13ecaf80fa775799a2.


This was causing an issue when setting the header from visible back to hidden. Header height was still being calculated as if it were visible, causing a black bar along the bottom of display.