### PR TITLE
fix(dashboard): prevent overflow when header visible

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -291,8 +291,42 @@ button_card_templates:
         - grid-template-columns: 1fr 1fr
         - row-gap: .5rem
       card:
-        - min-height: 100vh
-        - max-height: 100vh
+        - min-height: |-
+            [[[
+              try {
+                const screenMode = hass.states[variables.var_assistsat_entity]?.attributes?.screen_mode;
+                if (screenMode === 'no_hide' || screenMode === 'hide_sidebar') {
+                  return 'calc(100vh - var(--header-height))';
+                }
+                return '100vh';
+              } catch {
+                return '100vh';
+              }
+            ]]]
+        - max-height: |-
+            [[[
+              try {
+                const screenMode = hass.states[variables.var_assistsat_entity]?.attributes?.screen_mode;
+                if (screenMode === 'no_hide' || screenMode === 'hide_sidebar') {
+                  return 'calc(100vh - var(--header-height))';
+                }
+                return '100vh';
+              } catch {
+                return '100vh';
+              }
+            ]]]
+        - height: |-
+            [[[
+              try {
+                const screenMode = hass.states[variables.var_assistsat_entity]?.attributes?.screen_mode;
+                if (screenMode === 'no_hide' || screenMode === 'hide_sidebar') {
+                  return 'calc(100vh - var(--header-height))';
+                }
+                return '100vh';
+              } catch {
+                return '100vh';
+              }
+            ]]]
         - aspect-ratio: |-
             [[[
               if (!window.viewAssistResponsive) return "16 / 9";
@@ -319,7 +353,6 @@ button_card_templates:
             ]]]
         - font-weight: 300
         - position: relative
-        - height: 100vh
         - box-sizing: border-box
       custom_fields:
         title:


### PR DESCRIPTION
Adjusts card height based on header visibility to prevent overflow.
When header is visible, subtracts header height from viewport.
When header is hidden, uses full viewport height.
Reads screen_mode attribute from device sensor entity to determine proper height for each device.

Needs https://github.com/dinki/view_assist_integration/pull/225 to work properly, but does not break anything without it.