### PR TITLE
feat(dashboard): Add Status Icons Support for Custom Dashboards in View Assist

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -515,6 +515,34 @@ button_card_templates:
 
                   return buttonList;
                 }]]]
+  status_icons_overlay:
+    template:
+      - variable_template
+      - responsive_base
+      - status_icons_content
+    show_state: false
+    show_icon: false
+    show_name: false
+    triggers_update: all
+    styles:
+      card: null
+      custom_fields:
+        status:
+          - position: fixed
+          - top: |-
+              [[[
+                try {
+                  const screenMode = hass.states[variables.var_assistsat_entity]?.attributes?.screen_mode;
+                  if (screenMode === 'no_hide' || screenMode === 'hide_sidebar') {
+                    return 'calc(0vh + var(--header-height))';
+                  }
+                  return '0vh';
+                } catch {
+                  return '0vh';
+                }
+              ]]]
+          - right: 0vw
+          - z-index: 4
   icon_template:
     template: variable_template
     color_type: card


### PR DESCRIPTION
Enables users to integrate their own custom dashboards (especially sections views) into View Assist while maintaining the signature status icons display in the upper right corner, providing a consistent View Assist experience across all views.

### Changes
- **Refactored** status icons logic into `status_icons_content` shared template
- **Added** `status_icons_overlay` template for sections views
- **Updated** `body_template` to use shared template

### Usage
Add status icons to any view:
```yaml
type: custom:button-card
template:
  - status_icons_overlay
```

The status icons will appear in the upper right corner just like they do in native View Assist views.