### PR TITLE
feat(dashboard): add hold mode to menu button hold action

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -688,6 +688,12 @@ button_card_templates:
         show: >-
           [[[ return
           !states[variables.var_assistsat_entity].attributes.menu_active ]]]
+    hold_action:
+      action: call-service
+      service: view_assist.set_state
+      service_data:
+        entity_id: '[[[ return variables.var_assistsat_entity ]]]'
+        mode: hold
   camera:
     type: custom:button-card
     template: icon_template


### PR DESCRIPTION
Enables setting hold mode by holding the menu button, providing an accessible alternative for views where tapping open card areas is difficult or impossible (camera views, media players, sections views).