### PR TITLE
Fix scores blueprint to include teamtracker entities

### DIFF
--- a/View_Assist_custom_sentences/Get_Sports_Scores/blueprint-getsportsscores.yaml
+++ b/View_Assist_custom_sentences/Get_Sports_Scores/blueprint-getsportsscores.yaml
@@ -36,8 +36,7 @@ blueprint:
       selector:
         entity:
           filter:
-            - domain:
-                - teamtracker
+            - integration: teamtracker
           multiple: false
     college_teams:
       name: College Teams


### PR DESCRIPTION
Can't get any teamtracker entities to show up without this change