### PR TITLE
Updated satellite selector ind devicealerts to only show satellite sensors

### DIFF
--- a/View_Assist_custom_sentences/Device_Alerts/blueprint-devicealerts.yaml
+++ b/View_Assist_custom_sentences/Device_Alerts/blueprint-devicealerts.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - Device Alerts
-  description: This blueprint allows the user to define an event that will add an icon, speak an announcement, and/or display a screen with status.  It will optionally do the same for an ending event (View Assist devicealert v 1.0.1a)
+  description: This blueprint allows the user to define an event that will add an icon, speak an announcement, and/or display a screen with status.  It will optionally do the same for an ending event (View Assist devicealert v 1.0.2)
   domain: automation
   input:
     satellite_use_all:


### PR DESCRIPTION
For the satellite entity selector in the existing blue-print-devicealerts.yaml, the only filter was for devices belonging to the integration. However if there is an update to the integration, then that also shows up as a selectable satellite. For example, HA is showing me "View Assist - Get Sport Scores blueprint" as an update, and since it belongs to the View Assist integration it shows up in the list of satellites in the Blueprint. This fix adds an additional filter (domain: sensor) which is ANDed with the Integration filter to only show the true View Assist satellites.