### PR TITLE
Added #316. Added satellite selection via template, updates the related description and handles user not selecting a satellite.

### DIFF
--- a/View_Assist_custom_sentences/Device_Alerts/blueprint-devicealerts.yaml
+++ b/View_Assist_custom_sentences/Device_Alerts/blueprint-devicealerts.yaml
@@ -3,21 +3,33 @@ blueprint:
   description: This blueprint allows the user to define an event that will add an icon, speak an announcement, and/or display a screen with status.  It will optionally do the same for an ending event (View Assist devicealert v 1.0.2)
   domain: automation
   input:
-    satellite_use_all:
-      name: Use All Satellites
-      description: Check this box to use all View Assist Satellites instead of selecting specific entities
-      default: false
-      selector:
-        boolean:
-    satellite:
-      name: Specific Satellites
-      description: The View Assist individual device entities to display the alert on.  Multiple satellite selection acceptable.  Do not use this option if use all option above is enabled! (example sensor.viewassist_living_room)
-      selector:
-        entity:
-          multiple: true
-          filter:
-            - integration: view_assist
-              domain: sensor
+    satellite_definitions:
+      name: Satellite Selections
+      description: These options define which satellites to use. Choose one of the 3 options below. Note, if you select more than one option, it evaluates them in the order 1,2,3 and will use the first of those that you have defined.
+      input:
+        satellite_use_all:
+          name: (1) Use All Satellites
+          description: Check this box to use all View Assist Satellites.
+          default: false
+          selector:
+            boolean: {}
+        satellite:
+          name: (2) Specific Satellites
+          description: Choose to always use only specific satellite(s). Multiple satellite selection acceptable. (example sensor.viewassist_living_room)
+          selector:
+            entity:
+              multiple: true
+              filter:
+              - integration: view_assist
+                domain:
+                - sensor
+              reorder: false
+        satellites_by_template:
+          name: (3) Dynamic Satellites
+          description: Dynamically choose the satellites using a template. Note that the template must return a list [].
+          default: ''
+          selector:
+            template:
     start_definitions:
       name: Start Alert Definitions
       description: These options are used for the variables needed for the start condition for the alert
@@ -143,13 +155,16 @@ actions:
   - variables:
       satellite: !input satellite
       satellite_use_all: !input satellite_use_all
+      satellites_by_template: !input satellites_by_template
       expanded_satellites: >
-        {% if satellite_use_all %}
+        {% if satellite_use_all %}  
           {{ view_assist_entities() }}
+        {% elif satellite is defined and satellite %}
+          {% set input_satellites = expand(states | selectattr('entity_id','in', satellite)) %}
+          {{ input_satellites | map(attribute='entity_id') | list}}
         {% else %}
-          {% set input_satellites = expand(states | selectattr('entity_id', 'in', satellite)) %}
-          {{ input_satellites | map(attribute='entity_id') | list }}
-        {% endif %}
+          {{ satellites_by_template }}
+        {% endif %}        
       start_icon: !input start_icon
       start_speech: !input start_speech
       start_alert: !input start_alert
@@ -159,6 +174,10 @@ actions:
       end_alert: !input end_alert
       end_view: !input end_view
   - choose:
+      - conditions: 
+        - condition: template
+          value_template: "{{ expanded_satellites | length < 1 }}"
+        sequence: []    
       - conditions:
           - condition: trigger
             id: startaction


### PR DESCRIPTION
Added the feature I suggested in #316 - allowing satellite selection via template.
As part of that:
* I updated the text around the satellite options
* made satellites their own "section" of the UI.
* made sure in the logic that if no satellite options are chosen that it just skips everything (ie: does not error).
