### PR TITLE
Fixed single pixel appearing in night mode view for clock

### DIFF
--- a/View Assist dashboard and views/views/clock/clock.yaml
+++ b/View Assist dashboard and views/views/clock/clock.yaml
@@ -144,5 +144,5 @@ custom_fields:
           - color: "[[[ return variables.var_font_color_night ]]]"
   time: "[[[ return variables.var_current_time ]]]"
   date: "[[[ return variables.var_date_short ]]]"
-  night: .
+  night: ""
   shader: ""


### PR DESCRIPTION
As far as I understand, the last line in the `yaml` for the clock view was the culprit for creating a single white pixel in the clock night view. Unless there was a specific reason for this to be like that, the solution should be to leave an empty string. 