### PR TITLE
support times from google stt api

### DIFF
--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
@@ -112,7 +112,7 @@ action:
           - variables:
               device_id: "{{ trigger.device_id }}"
               type: "{{ trigger.id }}"
-              time: "{{ trigger.slots.when }}"
+              time: "{{ trigger.slots.when | regex_replace('-', ' ') }}"
               name: '{{ trigger.slots.name if trigger.slots.name is defined else "" }}'
               language: "{{ trigger.user_input.language }}"
           - action: view_assist.set_timer


### PR DESCRIPTION
Using Google's Speech to Text API the timer values are returned with hyphens in them. Examples: "5-minute" or "10-second".

Regexing out the hyphens allow the blueprint to interpret time from Google STT API, and prevents the error:
"Unable to decode time or interval information"