### PR TITLE
Hide home icon when on configured home view instead of hardcoded clock view

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -1,7 +1,7 @@
 button_card_templates:
   variable_template:
     variables:
-      dashboardversion: 1.3.1
+      dashboardversion: 1.3.2
       var_assistsat_entity: |-
         [[[
           return localStorage.getItem("view_assist_sensor")


### PR DESCRIPTION
Fixes home icon to be hidden on the configured home screen. Currently, this is hardcoded for the clock view. This was causing an issue for users that had a different view set as their home scree where the home button wouldn't appear on the clock view but would also appear incorrectly, and uselessly, on their configured home screen.

Related: dinki/view_assist_integration/pull/246