### PR TITLE
Add Italian translations to core blueprints

### DIFF
--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Alarms Reminders Timers
   description:
     Ask Assist to set an alarm, reminder, or timer  (View Assist alarmsreminderstimers
-    v 1.3.1)
+    v 1.3.2)
   domain: automation
   input:
     spokenlanguage:
@@ -17,6 +17,7 @@ blueprint:
             - en
             - es
             - fr
+            - it
             - pt
             - sr
             - sr-Latn
@@ -283,6 +284,17 @@ action:
             named_timer_not_found: "Ce minuteur est introuvable"
             timer_not_found: "Le {timer_info} est introuvable"
             time_left: "Il reste {time_left} sur votre minuteur de {timer_info}"
+        it:
+          responses:
+            no_active_timers: "Non ci sono timer attivi."
+            one_active_timer: "C'è un timer attivo:"
+            multiple_active_timers: "Ci sono {count} timer attivi:"
+            final_timer: "e {timer_expiry_speak}"
+            no_display: "Questo dispositivo non ha uno schermo per mostrare i timer"
+            timer_cancel: "Ho annullato {timer_info}"
+            named_timer_not_found: "Non ho trovato quel timer"
+            timer_not_found: "Non ho trovato {timer_info}"
+            time_left: "Restano {time_left} sul tuo {timer_info}"
         pt:
           responses:
             no_active_timers: "Não existem timers ativos."

--- a/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
+++ b/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Device Functions
   description:
     Various device functions for the View Assist Satellites (View Assist
-    devicefunctions v 1.4.6)
+    devicefunctions v 1.4.7)
   domain: automation
   input:
     language:
@@ -11,7 +11,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, nl, pl, pt, sr, sr-Latn]
+          languages: [ca, de, en, es, it, nl, pl, pt, sr, sr-Latn]
     repeat_command:
       name: Repeat Command
       description: The phrase you want to use to trigger repeating last spoken response
@@ -156,6 +156,20 @@ action:
             volume_set: "El volumen se ha ajustado a {level}"
             volume_adjusted: "El volumen ha sido {direction}"
             sound_restored: "El sonido se ha restaurado"
+        it:
+          responses:
+            repeat: "Ho detto {last_said}"
+            repeat_remove: "Ho detto"
+            do_not_disturb_off: "La modalità non disturbare è disattivata"
+            mode_success: "Imposto la modalità {mode}"
+            mode_failure_device: "Mi dispiace, {mode} non è una modalità valida per questo dispositivo"
+            mode_failure_unrecognized: "Mi dispiace, {mode} non è una modalità valida. Prova con {{ modes }}."
+            info_playing: "Stai ascoltando {title} di {artist}"
+            view_switch: "Passo alla vista {view}"
+            view_invalid: "Mi dispiace, {view} non è una vista valida."
+            volume_set: "Volume impostato a {level}"
+            volume_adjusted: "Il volume è stato {direction}"
+            sound_restored: "Audio riattivato"
         nl:
           responses:
             repeat: "Ik zei {last_said}"

--- a/View_Assist_custom_sentences/Play_Music_with_Music_Assistant/blueprint-playmusicwithmusicassistant.yaml
+++ b/View_Assist_custom_sentences/Play_Music_with_Music_Assistant/blueprint-playmusicwithmusicassistant.yaml
@@ -3,7 +3,7 @@ blueprint:
   description:
     Use various methods to play individual songs, add to queue, play artist
     and playlists from your Music Assistant server (View Assist Play Music with Music
-    Assistant v 1.2.7)
+    Assistant v 1.2.8)
   domain: automation
   input:
     ma_instance:
@@ -29,6 +29,7 @@ blueprint:
             - de
             - en
             - es
+            - it
             - nl
             - pl
             - pt
@@ -128,6 +129,15 @@ actions:
             playsong_found: "Reproduciendo {song} de {artist}"
             playsong_not_found: "Lo siento, no se ha encontrado {song} de {artist}"
             playsong_queue: "Añadiendo a la cola {song} de {artist}"
+        it:
+          responses:
+            playartist_found: "Riproduco la musica di {artist}"
+            playartist_not_found: "Non ho trovato musica di {search_artist}"
+            playlist_found: "Riproduco la playlist {playlist}"
+            playlist_not_found: "Mi dispiace, non ho trovato nessuna playlist chiamata {search_playlist}"
+            playsong_found: "Riproduco {song} di {artist}"
+            playsong_not_found: "Mi dispiace, non ho trovato {song} di {artist}"
+            playsong_queue: "Aggiungo alla coda {song} di {artist}"
         nl:
           responses:
             playartist_found: Muziek van {artist} afspelen

--- a/View_Assist_custom_sentences/Play_Radio_with_Music_Assistant/blueprint-playradiowithmusicassistant.yaml
+++ b/View_Assist_custom_sentences/Play_Radio_with_Music_Assistant/blueprint-playradiowithmusicassistant.yaml
@@ -1,7 +1,7 @@
 blueprint:
   name: View Assist - Play Radio with Music Assistant
   description: Play radio stations from your Music Assistant server (View Assist
-    Play Radio with Music Assistant v 1.3.2)
+    Play Radio with Music Assistant v 1.3.3)
   domain: automation
   input:
     language:
@@ -10,7 +10,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, nl, pt, ro]
+          languages: [ca, de, en, es, it, nl, pt, ro]
     command:
       name: Command
       description: >-
@@ -156,6 +156,10 @@ action:
           responses:
             playing_station: "Spiele {station}"
             station_not_found: "Ich konnte {station} nicht finden. Bitte lege den Sender als Alias an."
+        it:
+          responses:
+            playing_station: "Riproduco {station}"
+            station_not_found: "Non ho trovato {station}. Aggiungila come alias."
         nl:
           responses:
             playing_station: "{station} afspelen"

--- a/View_Assist_custom_sentences/Search_Wikipedia/blueprint-searchwikipedia.yaml
+++ b/View_Assist_custom_sentences/Search_Wikipedia/blueprint-searchwikipedia.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - Search Wikipedia
-  description: Search for a search term using Wikipedia (View Assist wikisearch v 1.1.4)
+  description: Search for a search term using Wikipedia (View Assist wikisearch v 1.1.5)
   domain: automation
   input:
     language:
@@ -9,7 +9,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, pl, pt]
+          languages: [ca, de, en, es, it, pl, pt]
     command:
       name: Command
       description: The phrase you want to use to trigger searching Wikipedia
@@ -50,6 +50,10 @@ action:
           responses:
             view_title: "Búsqueda en Wikipedia"
             search_error: "Lo siento, no he podido encontrar nada en Wikipedia para eso"
+        it:
+          responses:
+            view_title: "Ricerca su Wikipedia"
+            search_error: "Mi dispiace, non ho trovato niente su Wikipedia"
         pl:
           responses:
             view_title: "Wyszukiwanie Wikipedia"

--- a/View_Assist_custom_sentences/Thermostat_Control/blueprint-thermostatcontrol.yaml
+++ b/View_Assist_custom_sentences/Thermostat_Control/blueprint-thermostatcontrol.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - Thermostat Control
-  description: Control thermostat temperature  (View Assist thermostatcontrol v 1.1.5)
+  description: Control thermostat temperature  (View Assist thermostatcontrol v 1.1.6)
   domain: automation
   input:
     language:
@@ -9,7 +9,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, nl, pl, pt]
+          languages: [ca, de, en, es, it, nl, pl, pt]
     increasetemperature:
       name: Increase Temperature
       description: The phrase used to increase the current thermostat temperature set point
@@ -90,6 +90,13 @@ action:
             tstat_set: "La temperatura del termostato se ha establecido en {amount} grados"
             tstat_show: "Mostrando el termostato"
             tstat_display_error: "Lo siento. Este dispositivo no puede mostrar el termostato"
+        it:
+          responses:
+            tstat_raise: "Ho alzato la temperatura del termostato di {amount} gradi"
+            tstat_lower: "Ho abbassato la temperatura del termostato di {amount} gradi"
+            tstat_set: "Ho impostato il termostato a {amount} gradi"
+            tstat_show: "Mostro il termostato"
+            tstat_display_error: "Mi dispiace, questo dispositivo non può mostrare il termostato"
         nl:
           responses:
             tstat_raise: "Thermostaat temperatuur verhoogd met {amount} graad"

--- a/View_Assist_custom_sentences/Travel_Times_by_Waze/blueprint-traveltimesbywaze.yaml
+++ b/View_Assist_custom_sentences/Travel_Times_by_Waze/blueprint-traveltimesbywaze.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - Travel Times by Waze
-  description: Get travel time estimates from Waze  (View Assist traveltimesbywaze v 1.0.3)
+  description: Get travel time estimates from Waze  (View Assist traveltimesbywaze v 1.0.4)
   domain: automation
   input:
     language:
@@ -9,7 +9,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, pl, pt]
+          languages: [ca, de, en, es, it, pl, pt]
     travelfromhome:
       name: Travel from home
       description: The phrase used to get directions from home
@@ -114,6 +114,13 @@ action:
             hoursandminutes: "{hours} horas y {minutes} minutos"
             minutesonly: "{minutes} minutos"
             viewtitle: "Tiempo de viaje"
+        it:
+          responses:
+            travelfromhome: "Ci vorranno circa {time} per arrivare a {destination}"
+            travelfromatob: "Ci vorranno circa {time} per andare da {origin} a {destination}"
+            hoursandminutes: "{hours} ore e {minutes} minuti"
+            minutesonly: "{minutes} minuti"
+            viewtitle: "Tempo di viaggio"
         pl:
           responses:
             travelfromhome: "Dojazd do {destination} zajmie około {time}"

--- a/View_Assist_custom_sentences/View_Camera/blueprint-viewcamera.yaml
+++ b/View_Assist_custom_sentences/View_Camera/blueprint-viewcamera.yaml
@@ -4,7 +4,7 @@ blueprint:
   description: |
     Ask View Assist to show your camera streams.
     Supports showing individual cameras or all cameras at once.
-    You can use multiple names for the same camera entity. (v 2.0.2)
+    You can use multiple names for the same camera entity. (v 2.0.3)
   domain: automation
   input:
     language:
@@ -13,7 +13,7 @@ blueprint:
       default: en
       selector:
         language:
-          languages: [ca, de, en, es, pl, pt]
+          languages: [ca, de, en, es, it, pl, pt]
     command:
       name: Command Text
       description: |
@@ -133,6 +133,11 @@ action:
                 camera_not_found_show: "Kamera '{camera}' nicht gefunden. Zeige konfigurierte Kameras."
                 camera_not_found_error: "Entschuldigung, ich konnte keine Kamera namens '{camera}' finden. Verfügbare Kameras sind: {available}."
                 camera_not_found_short: "Kamera '{camera}' nicht gefunden."
+            it:
+              responses:
+                camera_not_found_show: "Telecamera '{camera}' non trovata. Mostro le telecamere configurate."
+                camera_not_found_error: "Mi dispiace, non ho trovato nessuna telecamera chiamata '{camera}'. Le telecamere disponibili sono: {available}."
+                camera_not_found_short: "Telecamera '{camera}' non trovata."
             pl:
               responses:
                 camera_not_found_show: "Kamera '{camera}' nie znaleziona. Wyświetlam skonfigurowane kamery."

--- a/View_Assist_custom_sentences/What_time_is_it/blueprint-whattimeisit.yaml
+++ b/View_Assist_custom_sentences/What_time_is_it/blueprint-whattimeisit.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - What time is it
-  description: Ask Assist for time, date and day of the week and receive response (View Assist whattimeisit v 1.0.3)
+  description: Ask Assist for time, date and day of the week and receive response (View Assist whattimeisit v 1.0.4)
   domain: automation
   input:
     language:
@@ -168,7 +168,28 @@ action:
           responses:
             time: "Sono le {time}"
             day_of_week: "Oggi è {day_of_week}"
-            date: "Oggi è {date}"
+            date: "Oggi è {day_of_week} {day_of_month} {month} {year}"
+          weekdays:
+            mon: Lunedì
+            tue: Martedì
+            wed: Mercoledì
+            thu: Giovedì
+            fri: Venerdì
+            sat: Sabato
+            sun: Domenica
+          months:
+            jan: Gennaio
+            feb: Febbraio
+            mar: Marzo
+            apr: Aprile
+            may: Maggio
+            jun: Giugno
+            jul: Luglio
+            aug: Agosto
+            sep: Settembre
+            oct: Ottobre
+            nov: Novembre
+            dec: Dicembre
         nl:
           responses:
             time: "Het is {time}"

--- a/wiki/docs/extend-functionality/sentences/alarms-reminders-timers.md
+++ b/wiki/docs/extend-functionality/sentences/alarms-reminders-timers.md
@@ -40,6 +40,7 @@ Use your wakeword and say things like:
 
 | Version | Description                        |
 | ------- | ---------------------------------- |
+| v 1.3.2 | Add Italian translation            |
 | v 1.3.1 | Add lots of translations           |
 | v 1.3.0 | Major update to most functions     |
 | v 1.2.2 | Update title set order             |

--- a/wiki/docs/extend-functionality/sentences/device-functions.md
+++ b/wiki/docs/extend-functionality/sentences/device-functions.md
@@ -21,46 +21,57 @@ This blueprint will contain device specific functions. Current functions include
 
 - en: `(what did you say  | [please] say that again [please] | [please] repeat that [please])`
 - de: `(Was hast du gesagt  | [Bitte] sag das noch einmal [bitte] | [Bitte] wiederhole das [bitte])`
+- it: `(cosa hai detto | puoi ripetere | ripeti [per favore])`
 
 ### Mode Command
 
 - en: `(set mode [to] {mode} | turn on {mode} mode | set [to] {mode} mode)`
 - de: `(setze den Modus [auf] {mode} | schalte {mode} Modus ein | setze [auf] {mode} Modus)`
+- it: `(metti | attiva | imposta) [la] modalità {mode}`
 
 ### View Command
 
 - en: `(set view [to] {view} | change [to] {view} view | set [to] {view} view)`
 - de: `(setze [die] Ansicht [auf] {view} | wechsle [zu] {view} Ansicht | setze [auf] {view} Ansicht | Zeige [der|die|das] {view})`
+- it: `(vai alla vista {view} | mostra [la vista] {view} | metti la vista {view})`
 
 ### Do Not Disturb Command
 
 - en: `(set do not disturb [mode] [to] off | turn off do not disturb [mode] | end do not disturb [mode] | cancel do not disturb [mode])`
 - de: `(setze den Nicht stören [Modus] [auf] aus | schalte den Nicht stören [Modus] aus | beende den Nicht stören [Modus] | abbreche den Nicht stören [Modus])`
+- it: `(togli | disattiva | spegni) [la modalità] non disturbare`
 
 ### Set Volume Command
 
 - en: `[set | turn] [the] volume [to] {level}`
 - de: `[Setze | Schalte] [die] Lautstärke [auf] {level}`
+- it: `[metti | imposta] [il] volume (a | al) {level}`
 
 ### Adjust Volume Command
 
 - en: `turn {up_down} [the] volume`
 - de: `Schalte [die] Lautstärke {up_down}`
+- it: `{up_down} il volume`
+
+_Note: the blueprint compares the `{up_down}` slot against the literal English words `up`/`down`, so translated direction words (e.g. Italian "alza"/"abbassa") are captured but not recognized yet._
 
 ### Mute Volume Command
 
 - en: `mute [the] [volume]`
 - de: `Schalte [die] Lautstärke stumm`
+- it: `(metti muto | muto | zitto | silenzio)`
 
 ### Unmute Volume Command
 
 - en: `unmute [the] [volume]`
 - de: `Schalte [die] Lautstärke [wieder] an`
+- it: `(togli il muto | riattiva l'audio | rimetti l'audio)`
 
 ### Stop Music Command
 
 - en: `stop [the] music`
 - de: `Stoppe [die] Musik`
+- it: `((ferma | stoppa | spegni) la musica | basta musica)`
 
 ## Changelog
 

--- a/wiki/docs/extend-functionality/sentences/device-functions.md
+++ b/wiki/docs/extend-functionality/sentences/device-functions.md
@@ -66,6 +66,7 @@ This blueprint will contain device specific functions. Current functions include
 
 | Version | Description                                                                              |
 | ------- | ---------------------------------------------------------------------------------------- |
+| v 1.4.7 | Add Italian translation                                                                  |
 | v 1.4.6 | Added translations                                                                       |
 | v 1.4.5 | Add Serbian translations                                                                 |
 | v 1.4.4 | Explicitly set path for setting view                                                     |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -19,7 +19,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Locate a Person](sentences/locate-a-person)                    | Ask for the location of a family member and see it displayed on a map                 | en, ca, de, es, it, pl                              |
 | [Play Music with Music Assistant](sentences/play-music-with-ma) | Play your music media using Music Assistant                                           | en, ca, de, es, it, nl, pl, pt, ro                  |
 | [Play Radio with Music Assistant](sentences/play-radio-with-ma) | Play TuneIn radio using Music Assistant                                               | en, ca, de, es, it, nl, pt, ro                      |
-| [Search Wikipedia](sentences/search-wikipedia)                  | Search Wikipedia using voice and receive a response and image on view enabled devices | en, ca, de, es, pl                                  |
+| [Search Wikipedia](sentences/search-wikipedia)                  | Search Wikipedia using voice and receive a response and image on view enabled devices | en, ca, de, es, it, pl, pt                          |
 | [Show Webpage](sentences/show-webpage)                          | Show your favorite website on your view enabled device                                | en                                                  |
 | [Sound Machine](sentences/sound-machine)                        | Enables the user to play ambient sounds for relaxation or noise cancelation           | en                                                  |
 | [Spell a Word](sentences/spell-a-word)                          | Ask View Assist to spell a word and get a response back with the spelling             | en, ca, de, es, fr, it, pl                          |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -12,7 +12,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Alarms Reminders & Timers](sentences/alarms-reminders-timers)  | Allows for an on demand call to create and list alarms, reminders and timers          | en, ca, de, es, fr, it, pt, sr, sr-Latn             |
 | [Broadcast](sentences/broadcast)                                | Broadcast messages to other View Assist Satellites                                    | Universal                                           |
 | [Device Alerts](sentences/device-alerts)                        | Automation builder used to do something with a VA satellite when something happens    | Universal                                           |
-| [Device Functions](sentences/device-functions)                  | Extend device functions for media control, modes and repeat speech                    | en, ca, de, es, nl, pl, pt, sr, sr-Latn             |
+| [Device Functions](sentences/device-functions)                  | Extend device functions for media control, modes and repeat speech                    | en, ca, de, es, it, nl, pl, pt, sr, sr-Latn         |
 | [Get Sports Scores](sentences/get-sports-scores)                | Get sports scores from US major sports teams and custom definitions                   | en, ca, de, es, fr, it, pl, pt                      |
 | [How\'s the Weather](sentences/hows-the-weather)                | Get current conditions and see the forecast on view enabled devices                   | en, ca, de, es, fr, it, nl, pl, pt, ro, sr, sr-Latn |
 | [List Management](sentences/list-management)                    | Add, remove, show items from your shopping or to do list                              | en, ca, de, es, fr, it, pl, ro                      |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -25,7 +25,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Spell a Word](sentences/spell-a-word)                          | Ask View Assist to spell a word and get a response back with the spelling             | en, ca, de, es, fr, it, pl                          |
 | [Thank You](sentences/thank-you)                                | Show your gratitude and receive a kind reply                                          | en                                                  |
 | [Thermostat Control](sentences/thermostat-control)              | Control the temperature of your thermostat by voice                                   | en, ca, de, es, it, nl, pl, pt                      |
-| [Travel Times by Waze](sentences/travel-times-by-waze)          | Get realtime travel times using Waze                                                  | en, ca, de, es                                      |
+| [Travel Times by Waze](sentences/travel-times-by-waze)          | Get realtime travel times using Waze                                                  | en, ca, de, es, it, pl, pt                          |
 | [View Calendar](sentences/view-calendar)                        | Show your calendar events by requesting by voice                                      | en, pl                                              |
 | [View Camera](sentences/view-camera)                            | Use voice to show your security cameras                                               | en, ca, de, es, pl, pt                              |
 | [What time is it](sentences/what-time-is-it)                    | Get time and date by voice                                                            | en, ca, de, es, fr, it, nl, pl                      |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -17,7 +17,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [How\'s the Weather](sentences/hows-the-weather)                | Get current conditions and see the forecast on view enabled devices                   | en, ca, de, es, fr, it, nl, pl, pt, ro, sr, sr-Latn |
 | [List Management](sentences/list-management)                    | Add, remove, show items from your shopping or to do list                              | en, ca, de, es, fr, it, pl, ro                      |
 | [Locate a Person](sentences/locate-a-person)                    | Ask for the location of a family member and see it displayed on a map                 | en, ca, de, es, it, pl                              |
-| [Play Music with Music Assistant](sentences/play-music-with-ma) | Play your music media using Music Assistant                                           | en, ca, de, es,fr, nl, pl, pt, ro                   |
+| [Play Music with Music Assistant](sentences/play-music-with-ma) | Play your music media using Music Assistant                                           | en, ca, de, es, it, nl, pl, pt, ro                  |
 | [Play Radio with Music Assistant](sentences/play-radio-with-ma) | Play TuneIn radio using Music Assistant                                               | en, ca, de, es, nl, pt, ro                          |
 | [Search Wikipedia](sentences/search-wikipedia)                  | Search Wikipedia using voice and receive a response and image on view enabled devices | en, ca, de, es, pl                                  |
 | [Show Webpage](sentences/show-webpage)                          | Show your favorite website on your view enabled device                                | en                                                  |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -18,7 +18,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [List Management](sentences/list-management)                    | Add, remove, show items from your shopping or to do list                              | en, ca, de, es, fr, it, pl, ro                      |
 | [Locate a Person](sentences/locate-a-person)                    | Ask for the location of a family member and see it displayed on a map                 | en, ca, de, es, it, pl                              |
 | [Play Music with Music Assistant](sentences/play-music-with-ma) | Play your music media using Music Assistant                                           | en, ca, de, es, it, nl, pl, pt, ro                  |
-| [Play Radio with Music Assistant](sentences/play-radio-with-ma) | Play TuneIn radio using Music Assistant                                               | en, ca, de, es, nl, pt, ro                          |
+| [Play Radio with Music Assistant](sentences/play-radio-with-ma) | Play TuneIn radio using Music Assistant                                               | en, ca, de, es, it, nl, pt, ro                      |
 | [Search Wikipedia](sentences/search-wikipedia)                  | Search Wikipedia using voice and receive a response and image on view enabled devices | en, ca, de, es, pl                                  |
 | [Show Webpage](sentences/show-webpage)                          | Show your favorite website on your view enabled device                                | en                                                  |
 | [Sound Machine](sentences/sound-machine)                        | Enables the user to play ambient sounds for relaxation or noise cancelation           | en                                                  |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -27,7 +27,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Thermostat Control](sentences/thermostat-control)              | Control the temperature of your thermostat by voice                                   | en, ca, de, es, it, nl, pl, pt                      |
 | [Travel Times by Waze](sentences/travel-times-by-waze)          | Get realtime travel times using Waze                                                  | en, ca, de, es, it, pl, pt                          |
 | [View Calendar](sentences/view-calendar)                        | Show your calendar events by requesting by voice                                      | en, pl                                              |
-| [View Camera](sentences/view-camera)                            | Use voice to show your security cameras                                               | en, ca, de, es, pl, pt                              |
+| [View Camera](sentences/view-camera)                            | Use voice to show your security cameras                                               | en, ca, de, es, it, pl, pt                          |
 | [What time is it](sentences/what-time-is-it)                    | Get time and date by voice                                                            | en, ca, de, es, fr, it, nl, pl                      |
 
 We are always looking for additional translations. Can you help?

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -28,6 +28,6 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Travel Times by Waze](sentences/travel-times-by-waze)          | Get realtime travel times using Waze                                                  | en, ca, de, es, it, pl, pt                          |
 | [View Calendar](sentences/view-calendar)                        | Show your calendar events by requesting by voice                                      | en, pl                                              |
 | [View Camera](sentences/view-camera)                            | Use voice to show your security cameras                                               | en, ca, de, es, it, pl, pt                          |
-| [What time is it](sentences/what-time-is-it)                    | Get time and date by voice                                                            | en, ca, de, es, fr, it, nl, pl                      |
+| [What time is it](sentences/what-time-is-it)                    | Get time and date by voice                                                            | en, ca, de, es, fr, it, nl, pl, pt                  |
 
 We are always looking for additional translations. Can you help?

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -24,7 +24,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 | [Sound Machine](sentences/sound-machine)                        | Enables the user to play ambient sounds for relaxation or noise cancelation           | en                                                  |
 | [Spell a Word](sentences/spell-a-word)                          | Ask View Assist to spell a word and get a response back with the spelling             | en, ca, de, es, fr, it, pl                          |
 | [Thank You](sentences/thank-you)                                | Show your gratitude and receive a kind reply                                          | en                                                  |
-| [Thermostat Control](sentences/thermostat-control)              | Control the temperature of your thermostat by voice                                   | en, ca, de, es, nl, pl                              |
+| [Thermostat Control](sentences/thermostat-control)              | Control the temperature of your thermostat by voice                                   | en, ca, de, es, it, nl, pl, pt                      |
 | [Travel Times by Waze](sentences/travel-times-by-waze)          | Get realtime travel times using Waze                                                  | en, ca, de, es                                      |
 | [View Calendar](sentences/view-calendar)                        | Show your calendar events by requesting by voice                                      | en, pl                                              |
 | [View Camera](sentences/view-camera)                            | Use voice to show your security cameras                                               | en, ca, de, es, pl, pt                              |

--- a/wiki/docs/extend-functionality/sentences/index.md
+++ b/wiki/docs/extend-functionality/sentences/index.md
@@ -9,7 +9,7 @@ We encourage everyone to share their creations so that others might enjoy what y
 
 | Automations                                                     | Description                                                                           | Languages                                           |
 | --------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Alarms Reminders & Timers](sentences/alarms-reminders-timers)  | Allows for an on demand call to create and list alarms, reminders and timers          | en, ca, de, es, fr, pt, sr, sr-Latn                 |
+| [Alarms Reminders & Timers](sentences/alarms-reminders-timers)  | Allows for an on demand call to create and list alarms, reminders and timers          | en, ca, de, es, fr, it, pt, sr, sr-Latn             |
 | [Broadcast](sentences/broadcast)                                | Broadcast messages to other View Assist Satellites                                    | Universal                                           |
 | [Device Alerts](sentences/device-alerts)                        | Automation builder used to do something with a VA satellite when something happens    | Universal                                           |
 | [Device Functions](sentences/device-functions)                  | Extend device functions for media control, modes and repeat speech                    | en, ca, de, es, nl, pl, pt, sr, sr-Latn             |

--- a/wiki/docs/extend-functionality/sentences/play-music-with-ma.md
+++ b/wiki/docs/extend-functionality/sentences/play-music-with-ma.md
@@ -34,6 +34,7 @@ Adjustments may be needed based on your specific usage and preferences.
 
 | Version | Description                                                                                  |
 | ------- | -------------------------------------------------------------------------------------------- |
+| v 1.2.8 | Add Italian translation                                                                      |
 | v 1.2.6 | Return found artist and track instead of what was requested                                  |
 | v 1.2.5 | Add option to allow for blank artist in play song option                                     |
 | v 1.2.4 | Add Dutch translation                                                                        |

--- a/wiki/docs/extend-functionality/sentences/play-music-with-ma.md
+++ b/wiki/docs/extend-functionality/sentences/play-music-with-ma.md
@@ -14,21 +14,25 @@ Adjustments may be needed based on your specific usage and preferences.
 
 - en: `(play the artist {artist} | play some {artist} [music] |play [some] [music | songs] by {artist})`
 - de: `(Spiele den Künstler {artist} | Spiele etwas {artist} [Musik] | Spiele [etwas] [Musik | Lieder] von {artist})`
+- it: `(metti [un po' di] musica di {artist} | fammi sentire {artist} | riproduci [l'artista] {artist})`
 
 ### Play Playlist Command
 
 - en: `start [the] {playlist} playlist`
 - de: `Spiele [die] Playlist {playlist}`
+- it: `(metti | avvia | riproduci) la playlist {playlist}`
 
 ### Play Song Command
 
 - en: `play {song} by {artist}`
 - de: `Spiele [den Song|den Titel] {song} von {artist}`
+- it: `(metti | riproduci | fammi sentire) {song} di {artist}`
 
 ### Queue Song Command
 
 - en: `(queue | cue | Q) {song} by {artist}`
 - de: `Setze [den Song|den Titel] {song} von {artist} [in|auf] die Warteschlange`
+- it: `(metti in coda | accoda) {song} di {artist}`
 
 ## Changelog
 

--- a/wiki/docs/extend-functionality/sentences/play-radio-with-ma.md
+++ b/wiki/docs/extend-functionality/sentences/play-radio-with-ma.md
@@ -132,6 +132,7 @@ Find the station you want to use and copy the station ID exactly as shown in Mus
 
 | Version | Description                                                                                                     |
 | ------- | --------------------------------------------------------------------------------------------------------------- |
+| 1.3.3   | Add Italian translation                                                                                         |
 | 1.3.2   | Additional languages                                                                                            |
 | 1.3.0   | Various fixes                                                                                                   |
 | 1.3.0   | Added alias-based station matching, improved UI configuration, simplified logic, preserved legacy compatibility |

--- a/wiki/docs/extend-functionality/sentences/play-radio-with-ma.md
+++ b/wiki/docs/extend-functionality/sentences/play-radio-with-ma.md
@@ -82,11 +82,13 @@ You can continue using a legacy fixed command, or switch to the new alias-based 
 
 - en: `play Big 102.1`
 - de: `Spiele Big 102.1`
+- it: `metti Big 102.1`
 
 #### Alias-based example
 
 - en: `(start | play | listen) [to] radio [station] {station_name}`
 - de: `[den] (starte | spiele) radio [sender] {station_name} [hören]`
+- it: `(metti | accendi | avvia) [la] radio {station_name}`
 
 If you want to use aliases, your command must include `{station_name}`.
 

--- a/wiki/docs/extend-functionality/sentences/search-wikipedia.md
+++ b/wiki/docs/extend-functionality/sentences/search-wikipedia.md
@@ -16,6 +16,7 @@ Special thanks to Scratt for his work on this automation
 
 | Version | Description              |
 | ------- | ------------------------ |
+| v 1.1.5 | Add Italian translation  |
 | v 1.1.4 | Add more Translations    |
 | v 1.1.3 | Add Polish Translation   |
 | v 1.1.2 | Add German Translation   |

--- a/wiki/docs/extend-functionality/sentences/thermostat-control.md
+++ b/wiki/docs/extend-functionality/sentences/thermostat-control.md
@@ -21,6 +21,7 @@ Control your thermostat device using voice. User can say 'Raise temperature 2 de
 
 | Version | Description              |
 | ------- | ------------------------ |
+| v 1.1.6 | Add Italian translation  |
 | v 1.1.5 | Add translations         |
 | v 1.1.4 | Misc improvements        |
 | v 1.1.3 | Add Dutch translation    |

--- a/wiki/docs/extend-functionality/sentences/travel-times-by-waze.md
+++ b/wiki/docs/extend-functionality/sentences/travel-times-by-waze.md
@@ -19,6 +19,7 @@ Or import using [raw link](https://raw.githubusercontent.com/dinki/View-Assist/m
 
 | Version | Description            |
 | ------- | ---------------------- |
+| v 1.0.4 | Add Italian translation |
 | v 1.0.3 | Add translations       |
 | v 1.0.2 | Add Polish translation |
 | v 1.0.1 | Add German translation |

--- a/wiki/docs/extend-functionality/sentences/view-camera.md
+++ b/wiki/docs/extend-functionality/sentences/view-camera.md
@@ -22,6 +22,7 @@ Nothing additional
 
 | Version | Description                |
 | ------- | -------------------------- |
+| v 2.0.3 | Add Italian translation    |
 | v 2.0.2 | Add translations           |
 | v 2.0.1 | Update title set order     |
 | v 2.0.0 | Major improvements by Flab |

--- a/wiki/docs/extend-functionality/sentences/what-time-is-it.md
+++ b/wiki/docs/extend-functionality/sentences/what-time-is-it.md
@@ -10,6 +10,7 @@ User asks for the time or the date and receives response and screen switches to 
 
 | Version | Description                  |
 | ------- | ---------------------------- |
+| v 1.0.4 | Complete Italian translation |
 | v 1.0.3 | Add translations             |
 | v 1.0.2 | Add Polish translation       |
 | v 1.0.1 | Update for DE wrong variable |


### PR DESCRIPTION
Adds Italian (it) translations, reviewed by a native speaker:

- Alarms Reminders & Timers (v 1.3.2)
- Device Functions (v 1.4.7)
- Play Music with Music Assistant (v 1.2.8)
- Play Radio with Music Assistant (v 1.3.3)
- Search Wikipedia (v 1.1.5)
- Thermostat Control (v 1.1.6)
- Travel Times by Waze (v 1.0.4)
- View Camera (v 2.0.3)

Also completes the existing Italian block in What time is it (v 1.0.4): it only had `responses`, so asking for the day or date in Italian raised a template error (`translations[language]['weekdays']` missing). Added `weekdays`/`months` and switched the `date` response to the composed `{day_of_week} {day_of_month} {month} {year}` pattern (like de/pl), since `{date}` interpolates English month/day names from `strftime`.

Wiki updated accordingly (language tables + per-blueprint changelog rows). While editing those rows I also aligned a few language lists that had drifted from the blueprints (missing `pt`/`pl` in some rows; `fr` listed for Play Music which the blueprint doesn't have).

Also added Italian suggested command translations to the wiki pages that document them (Device Functions, Play Music with MA, Play Radio with MA), phrased colloquially rather than as literal translations. One caveat documented inline: the Adjust Volume action compares the `{up_down}` slot against the literal English words `up`/`down`, so translated direction words (Italian and German alike) are captured but not acted on — fixing that would need a per-language word mapping in the blueprint, which felt out of scope for a translation PR.

Note for maintainers: the `fr` and `nl` blocks in What time is it have the same missing-weekdays/months issue as Italian had — I didn't touch those since I'm not a native speaker, but happy to scaffold them if someone can review.
