### PR TITLE
Device Functions: split Adjust Volume into Volume Up/Down commands (fixes #437)

### DIFF
--- a/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
+++ b/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Device Functions
   description:
     Various device functions for the View Assist Satellites (View Assist
-    devicefunctions v 1.4.7)
+    devicefunctions v 1.5.0)
   domain: automation
   input:
     language:
@@ -34,10 +34,14 @@ blueprint:
       name: Set Volume Command
       description: The command to use to set volume level directly
       default: "[set | turn] [the] volume [to] {level}"
-    adjust_volume:
-      name: Adjust Volume Command
-      description: The command to use to set volume level by step
-      default: turn {up_down} [the] volume
+    volume_up_command:
+      name: Volume Up Command
+      description: The command to use to raise volume by one step
+      default: turn up [the] volume
+    volume_down_command:
+      name: Volume Down Command
+      description: The command to use to lower volume by one step
+      default: turn down [the] volume
     mute_volume:
       name: Mute Volume Command
       description: The command to use to mute audio
@@ -79,8 +83,11 @@ trigger:
     command: !input set_volume
     id: set_volume
   - trigger: conversation
-    command: !input adjust_volume
-    id: adjust_volume
+    command: !input volume_up_command
+    id: volume_up
+  - trigger: conversation
+    command: !input volume_down_command
+    id: volume_down
   - trigger: conversation
     command: !input mute_volume
     id: mute_volume
@@ -117,7 +124,8 @@ action:
             view_switch: "Canviant la vista a mode {view}"
             view_invalid: "Ho sento. {view} no és una vista vàlida"
             volume_set: "El volum s'ha ajustat a {level}"
-            volume_adjusted: "El volum s'ha {direction}"
+            volume_raised: "El volum s'ha apujat"
+            volume_lowered: "El volum s'ha abaixat"
             sound_restored: "El so s'ha restaurat"
         de:
           responses:
@@ -128,6 +136,12 @@ action:
             mode_failure_device: "Entschuldige. aber {mode} ist kein gültiger Modus für dieses Gerät"
             mode_failure_unrecognized: "Entschuldige, aber {mode} ist kein gültiger Modus. Bitte versuche es mit {{ modes }}."
             info_playing: "Es läuft {title} von {artist}"
+            view_switch: "Wechsle zur Ansicht {view}"
+            view_invalid: "Entschuldige. {view} ist keine gültige Ansicht."
+            volume_set: "Die Lautstärke wurde auf {level} gesetzt"
+            volume_raised: "Die Lautstärke wurde lauter gestellt"
+            volume_lowered: "Die Lautstärke wurde leiser gestellt"
+            sound_restored: "Der Ton wurde wiederhergestellt"
         en:
           responses:
             repeat: "I said {last_said}"
@@ -140,7 +154,8 @@ action:
             view_switch: "Switching view to {view} view"
             view_invalid: "Sorry. {view} is not a valid view."
             volume_set: "The volume was set to {level}"
-            volume_adjusted: "The volume has been turned {direction}"
+            volume_raised: "The volume has been turned up"
+            volume_lowered: "The volume has been turned down"
             sound_restored: "Sound has been restored"
         es:
           responses:
@@ -154,7 +169,8 @@ action:
             view_switch: "Cambiando la vista a modo {view}"
             view_invalid: "Lo siento. {view} no es una vista válida"
             volume_set: "El volumen se ha ajustado a {level}"
-            volume_adjusted: "El volumen ha sido {direction}"
+            volume_raised: "El volumen ha subido"
+            volume_lowered: "El volumen ha bajado"
             sound_restored: "El sonido se ha restaurado"
         it:
           responses:
@@ -168,7 +184,8 @@ action:
             view_switch: "Passo alla vista {view}"
             view_invalid: "Mi dispiace, {view} non è una vista valida."
             volume_set: "Volume impostato a {level}"
-            volume_adjusted: "Il volume è stato {direction}"
+            volume_raised: "Ho alzato il volume"
+            volume_lowered: "Ho abbassato il volume"
             sound_restored: "Audio riattivato"
         nl:
           responses:
@@ -179,11 +196,12 @@ action:
             mode_failure_device: "Sorry. {mode} is geen geldige modus voor dit apparaat"
             mode_failure_unrecognized: "Sorry. {mode} is geen geldige modus. Probeer {{ modes }}."
             info_playing: "Dit is {title} van {artist}"
-            view_switch: "Wechsle zur Ansicht {view}"
-            view_invalid: "Entschuldige. {view} ist keine gültige Ansicht."
-            volume_set: "Die Lautstärke wurde auf {level} gesetzt"
-            volume_adjusted: "Die Lautstärke wurde {direction} gestellt"
-            sound_restored: "Der Ton wurde wiederhergestellt"
+            view_switch: "Overschakelen naar weergave {view}"
+            view_invalid: "Sorry. {view} is geen geldige weergave."
+            volume_set: "Het volume is ingesteld op {level}"
+            volume_raised: "Het volume is verhoogd"
+            volume_lowered: "Het volume is verlaagd"
+            sound_restored: "Het geluid is hersteld"
         pl:
           responses:
             repeat: "Powiedziałem {last_said}"
@@ -196,7 +214,8 @@ action:
             view_switch: "Przełączam widok na {view}"
             view_invalid: "Przepraszam. {view} nie jest prawidłowym widokiem."
             volume_set: "Głośność ustawiona na {level}"
-            volume_adjusted: "Głośność została {direction}"
+            volume_raised: "Głośność została zwiększona"
+            volume_lowered: "Głośność została zmniejszona"
             sound_restored: "Dźwięk został przywrócony"
         pt:
           responses:
@@ -210,7 +229,8 @@ action:
             view_switch: "Mudando visualização para {view}"
             view_invalid: "Desculpe, {view} não é uma visualização válida"
             volume_set: "Volume definido para {level}"
-            volume_adjusted: "O volume foi ajustado para {direction}"
+            volume_raised: "O volume foi aumentado"
+            volume_lowered: "O volume foi diminuído"
             sound_restored: "O som foi restaurado"
         sr:
           responses:
@@ -224,7 +244,8 @@ action:
             view_switch: "Приказујем приказ {view}"
             view_invalid: "Жао ми је. {view} није важећи приказ."
             volume_set: "Јачина звука је подешена на {level}"
-            volume_adjusted: "Јачина звука је {direction}"
+            volume_raised: "Јачина звука је појачана"
+            volume_lowered: "Јачина звука је смањена"
             sound_restored: "Звук је враћен"
         sr-Latn:
           responses:
@@ -238,7 +259,8 @@ action:
             view_switch: "Prikazujem prikaz {view}"
             view_invalid: "Žao mi je. {view} nije važeći prikaz."
             volume_set: "Jačina zvuka je podešena na {level}"
-            volume_adjusted: "Jačina zvuka je {direction}"
+            volume_raised: "Jačina zvuka je pojačana"
+            volume_lowered: "Jačina zvuka je smanjena"
             sound_restored: "Zvuk je vraćen"
   - choose:
       - conditions:
@@ -374,14 +396,21 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - adjust_volume
+              - volume_up
         sequence:
-          - service:
-              '{% if trigger.slots.up_down == "down" %} media_player.volume_down {% endif %}
-              {% if trigger.slots.up_down == "up" %} media_player.volume_up {% endif %}'
+          - service: media_player.volume_up
             target:
               entity_id: "{{ target_mediaplayer_device }}"
-          - set_conversation_response: "{{ translations[language]['responses']['volume_adjusted'].replace('{direction}', trigger.slots.up_down) }}"
+          - set_conversation_response: "{{ translations[language]['responses']['volume_raised'] }}"
+      - conditions:
+          - condition: trigger
+            id:
+              - volume_down
+        sequence:
+          - service: media_player.volume_down
+            target:
+              entity_id: "{{ target_mediaplayer_device }}"
+          - set_conversation_response: "{{ translations[language]['responses']['volume_lowered'] }}"
       - conditions:
           - condition: trigger
             id:

--- a/wiki/docs/extend-functionality/sentences/device-functions.md
+++ b/wiki/docs/extend-functionality/sentences/device-functions.md
@@ -47,13 +47,17 @@ This blueprint will contain device specific functions. Current functions include
 - de: `[Setze | Schalte] [die] Lautstärke [auf] {level}`
 - it: `[metti | imposta] [il] volume (a | al) {level}`
 
-### Adjust Volume Command
+### Volume Up Command
 
-- en: `turn {up_down} [the] volume`
-- de: `Schalte [die] Lautstärke {up_down}`
-- it: `{up_down} il volume`
+- en: `turn up [the] volume`
+- de: `Schalte [die] Lautstärke lauter`
+- it: `(alza | aumenta) il volume`
 
-_Note: the blueprint compares the `{up_down}` slot against the literal English words `up`/`down`, so translated direction words (e.g. Italian "alza"/"abbassa") are captured but not recognized yet._
+### Volume Down Command
+
+- en: `turn down [the] volume`
+- de: `Schalte [die] Lautstärke leiser`
+- it: `(abbassa | diminuisci) il volume`
 
 ### Mute Volume Command
 
@@ -77,6 +81,7 @@ _Note: the blueprint compares the `{up_down}` slot against the literal English w
 
 | Version | Description                                                                              |
 | ------- | ---------------------------------------------------------------------------------------- |
+| v 1.5.0 | Split Adjust Volume into Volume Up/Down commands so translated phrases work; fix missing German response strings |
 | v 1.4.7 | Add Italian translation                                                                  |
 | v 1.4.6 | Added translations                                                                       |
 | v 1.4.5 | Add Serbian translations                                                                 |


### PR DESCRIPTION
Fixes #437.

**Note: this branch is stacked on #436** (Italian translations) — merge that first and this diff reduces to a single commit touching only Device Functions.

## What changed

- Replaced the `adjust_volume` input (`turn {up_down} [the] volume`) with two inputs, `volume_up_command` / `volume_down_command`, branching on trigger id — the same pattern Thermostat Control uses for raise/lower. Translated command phrases now work with no hidden dependency on the English words `up`/`down`.
- Replaced the `volume_adjusted` response (which echoed the raw slot word, producing things like "Il volume è stato **up**") with per-direction keys `volume_raised` / `volume_lowered` in **all** supported languages, derived from each language's existing `volume_adjusted` phrasing: ca, de, en, es, it, nl, pl, pt, sr, sr-Latn. Italian is native-reviewed; the others are conservative derivations — a native speaker's once-over is welcome.
- While in there, fixed a pre-existing swap: the `de:` block was missing `view_switch`, `view_invalid`, `volume_set` and `sound_restored`, and those German strings were sitting in the `nl:` block (German users currently get template errors on those code paths). Moved them home and gave `nl:` proper Dutch equivalents (also flagged for native review).
- Wiki: split the Adjust Volume suggested-command section into Volume Up / Volume Down (en/de/it examples), changelog row, version bump to v 1.5.0.

## Breaking change

Users who customized the old `adjust_volume` command need to re-enter their phrases in the two new inputs (everyone else just picks up the new defaults). Happy to adjust the approach if you'd rather keep the old input around.

Validated: YAML parses, and all 9 non-English language blocks have exact key parity with `en:`.