### PR TITLE
Update View Assist Broadcast blueprint to v1.1.2

### DIFF
--- a/View_Assist_custom_sentences/Broadcast/blueprint-broadcast.yaml
+++ b/View_Assist_custom_sentences/Broadcast/blueprint-broadcast.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Broadcast
   description:
     Say broadcast and the message and View Assist will send message to
-    all devices not in do not disturb mode (View Assist Broadcast v 1.1.1)<br />Note
+    all devices not in do not disturb mode (View Assist Broadcast v 1.1.2)<br />Note
     This blueprint only supports Home Assistant Assist Satellite compliant satellites (examples VACA and VPE)
   domain: automation
   input:
@@ -36,7 +36,7 @@ action:
       play_chime: !input play_chime
   - set_conversation_response: ""
   - repeat:
-      for_each: '{{ view_assist_entities(filter={"type":"view_audio"}, exclude={"mode":"hold"})}}'
+      for_each: '{{ view_assist_entities(filter={"type":["view_audio","vaca"]}, exclude={"mode":"hold"})}}'
       sequence:
         - action: view_assist.set_state
           target:


### PR DESCRIPTION
Updated blueprint version from 1.1.1 to 1.1.2 and modified the filter criteria for view audio entities to include vaca devices. Fixed issue #413

**Will require v2026.7.1 of view assist integration before releasing**