### PR TITLE
Fix timer blueprint target resolution for service events

### DIFF
--- a/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
+++ b/View_Assist_custom_sentences/Alarms_Reminders_Timers/blueprint-alarmsreminderstimers.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Alarms Reminders Timers
   description:
     Ask Assist to set an alarm, reminder, or timer  (View Assist alarmsreminderstimers
-    v 1.3.2)
+    v 1.3.3)
   domain: automation
   input:
     spokenlanguage:
@@ -207,9 +207,20 @@ trigger:
 condition: []
 action:
   - variables:
-      target_satellite_device:
-        "{{ view_assist_entity(trigger.device_id) if trigger.platform
-        == 'conversation' else trigger.event.data.entity_id }}"
+      target_satellite_device: >-
+        {% if trigger.platform == 'conversation' %}
+          {{ view_assist_entity(trigger.device_id) }}
+        {% else %}
+          {% set event_data = trigger.event.data if trigger.event is defined else {} %}
+          {% set service_data = event_data.get('service_data', {}) %}
+          {% if service_data.get('device_id') %}
+            {{ view_assist_entity(service_data.get('device_id')) }}
+          {% elif event_data.get('entity_id') %}
+            {{ event_data.get('entity_id') }}
+          {% else %}
+            {{ '' }}
+          {% endif %}
+        {% endif %}
       target_mediaplayer_device: "{{ state_attr(target_satellite_device, 'mediaplayer_device')}}"
       target_satellite_device_type: "{{ state_attr(target_satellite_device, 'type')}}"
       spokenlanguage: !input spokenlanguage

--- a/wiki/docs/extend-functionality/sentences/alarms-reminders-timers.md
+++ b/wiki/docs/extend-functionality/sentences/alarms-reminders-timers.md
@@ -40,6 +40,7 @@ Use your wakeword and say things like:
 
 | Version | Description                        |
 | ------- | ---------------------------------- |
+| v 1.3.3 | Fix target resolution for service events |
 | v 1.3.2 | Add Italian translation            |
 | v 1.3.1 | Add lots of translations           |
 | v 1.3.0 | Major update to most functions     |


### PR DESCRIPTION
# Fix timer blueprint target resolution for service events

## Summary

`call_service` events keep service parameters under `event.data.service_data`, while timer and UI events expose `entity_id` at the event-data level. The blueprint currently assumes every non-conversation trigger has a top-level `entity_id`, so service calls such as `set_timer(device_id=...)` and `cancel_timer(timer_id=...)` can fail during initial variable evaluation.

This change:

- preserves conversation-device resolution through `view_assist_entity`;
- resolves service-call `device_id` through `view_assist_entity`;
- falls back to a top-level event `entity_id`;
- returns an empty target when the event has no device or entity;
- bumps the blueprint to `1.3.3` and adds the matching wiki changelog entry.

The empty fallback intentionally allows timer-ID-only cancellation to reach its existing global cleanup branch. It does not infer a satellite from the timer ID.

## Validation completed

- exact resolver matrix: 8/8 using Jinja with strict undefined values;
- the same 8/8 matrix rendered through Home Assistant Core's real template API;
- the exact candidate blueprint was copied to an unused blueprint path, matched by SHA-256, and passed `ha core check`; the temporary copy was then removed;
- live `set_timer(device_id=A)` created the timer and status icon on satellite A and triggered the automation without `UndefinedError`;
- live `cancel_timer(timer_id=...)` removed the timer, cleared its icon, and completed the global cleanup branch;
- YAML parsed with Home Assistant's `!input` tags accounted for;
- CRLF-only line endings and the final CRLF are preserved;
- the diff is limited to two files and three intentional hunks;
- the Docusaurus wiki production build succeeds.

## Test-boundary note

The available deployment has one View Assist satellite. Isolation and precedence were therefore tested with real satellite A plus a synthetic entity B in the Home Assistant template matrix. Warning, expiry, Snooze, and Dismiss belong to unchanged branches outside this resolver-specific gate; they are not claimed as tested here.

## Scope and known limits

This change does not modify translations, Italian responses, sentence lists, integration code, or other automation branches. It also does not add end-to-end support for `set_timer` calls that provide only `entity_id` or no target: the existing `set_timer_trigger` branch still reads `service_data.device_id` when retrieving timers. Those forms remain documented limits, not positive acceptance cases.

**AI assistance disclosure:** AI tools assisted with research and drafting. I reviewed the complete diff and personally verified the tests and behavior described above.
