### PR TITLE
Stop Set Volume from swallowing direction phrases (Device Functions v 1.5.1)

### DIFF
--- a/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
+++ b/View_Assist_custom_sentences/Device_Functions/blueprint-devicefunctions.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: View Assist - Device Functions
   description:
     Various device functions for the View Assist Satellites (View Assist
-    devicefunctions v 1.5.0)
+    devicefunctions v 1.5.1)
   domain: automation
   input:
     language:
@@ -33,15 +33,15 @@ blueprint:
     set_volume:
       name: Set Volume Command
       description: The command to use to set volume level directly
-      default: "[set | turn] [the] volume [to] {level}"
+      default: "[set | turn] [the] volume to {level}"
     volume_up_command:
       name: Volume Up Command
       description: The command to use to raise volume by one step
-      default: turn up [the] volume
+      default: "(turn up [the] volume | turn [the] volume up)"
     volume_down_command:
       name: Volume Down Command
       description: The command to use to lower volume by one step
-      default: turn down [the] volume
+      default: "(turn down [the] volume | turn [the] volume down)"
     mute_volume:
       name: Mute Volume Command
       description: The command to use to mute audio
@@ -380,15 +380,19 @@ action:
             id:
               - set_volume
         sequence:
+          - variables:
+              requested_volume: >-
+                {% set level = trigger.slots.level | string | trim %}
+                {% if level.endswith('%') %}
+                {{ (level | replace('%', '') | int(-1))/100 }}
+                {% else %}
+                {{ (level | int(-1))/10 }}
+                {% endif %}
+          - condition: template
+            value_template: "{{ requested_volume | float(-1) >= 0 and requested_volume | float(-1) <= 1 }}"
           - action: media_player.volume_set
             data:
-              volume_level: '{% if trigger.id == "set_volume" %}
-                {% if trigger.slots.level.endswith(''%'') %}
-                {{ (trigger.slots.level |replace(''%'','' '') | int)/100 }}
-                {% else %}
-                {{ (trigger.slots.level | int)/10 }}
-                {% endif %}
-                {% endif %}'
+              volume_level: "{{ requested_volume | float }}"
             target:
               entity_id: "{{ target_mediaplayer_device }}"
           - set_conversation_response: "{{ translations[language]['responses']['volume_set'].replace('{level}', trigger.slots.level) }}"

--- a/wiki/docs/extend-functionality/sentences/device-functions.md
+++ b/wiki/docs/extend-functionality/sentences/device-functions.md
@@ -43,19 +43,23 @@ This blueprint will contain device specific functions. Current functions include
 
 ### Set Volume Command
 
-- en: `[set | turn] [the] volume [to] {level}`
-- de: `[Setze | Schalte] [die] Lautstärke [auf] {level}`
+- en: `[set | turn] [the] volume to {level}`
+- de: `[Setze | Schalte] [die] Lautstärke auf {level}`
 - it: `[metti | imposta] [il] volume (a | al) {level}`
+
+The word before `{level}` (`to`, `auf`, `a | al`) is required on purpose: `{level}` is a
+wildcard, so making it optional lets this command swallow the step phrases below and
+capture a direction word as the volume level.
 
 ### Volume Up Command
 
-- en: `turn up [the] volume`
+- en: `(turn up [the] volume | turn [the] volume up)`
 - de: `Schalte [die] Lautstärke lauter`
 - it: `(alza | aumenta) il volume`
 
 ### Volume Down Command
 
-- en: `turn down [the] volume`
+- en: `(turn down [the] volume | turn [the] volume down)`
 - de: `Schalte [die] Lautstärke leiser`
 - it: `(abbassa | diminuisci) il volume`
 
@@ -81,6 +85,7 @@ This blueprint will contain device specific functions. Current functions include
 
 | Version | Description                                                                              |
 | ------- | ---------------------------------------------------------------------------------------- |
+| v 1.5.1 | Stop Set Volume from swallowing "turn the volume up/down"; ignore non-numeric levels instead of aborting the run |
 | v 1.5.0 | Split Adjust Volume into Volume Up/Down commands so translated phrases work; fix missing German response strings |
 | v 1.4.7 | Add Italian translation                                                                  |
 | v 1.4.6 | Added translations                                                                       |


### PR DESCRIPTION
Fixes #461.

## The problem

Set Volume ships as `[set | turn] [the] volume [to] {level}`. The preposition is optional and `{level}` is a wildcard, so the command also matches the Volume Up and Volume Down phrases and captures the direction word as the level. `(trigger.slots.level | int)` has no default, so it raises, the run aborts, and the user hears nothing.

@kalowinta's analysis is right, including the part about #437 not covering the trailing-direction phrasing. I re-checked it with hassil 3.11 against the shipped defaults, and against the way Home Assistant matches sentence triggers (`conversation/default_agent.py` walks `recognize_all` and keeps the first result per trigger, so every distinct trigger that matches gets fired):

| Phrase | Before | After |
| --- | --- | --- |
| `turn the volume up` (en) | Set Volume alone, `level='up'`, ValueError, silence | Volume Up |
| `Schalte die Lautstärke lauter` (de) | Set Volume **and** Volume Up both fire, so the volume steps and you get a traceback every time | Volume Up |
| `imposta il volume a 5` (it) | already correct | unchanged |

The German suggested command in the wiki carried the same optional-preposition shape, so German users hit this too. Italian already required `a | al` and never saw it.

One thing I checked while I was in there, in case it needed handling too: the loose pattern also produces a second match that captures the preposition (`level='to 5'`). It never won, because hassil returns the clean capture first and HA keeps only the first result per trigger, so valid phrases never reached the conversion.

## Changes

1. Set Volume requires the preposition (`[set | turn] [the] volume to {level}`), so it can no longer match a step phrase.
2. Volume Up and Volume Down also accept the trailing-direction phrasing: `(turn up [the] volume | turn [the] volume up)`.
3. The level goes through a `requested_volume` variable with an `int(-1)` fallback, and `media_player.volume_set` runs only when the result lands in 0-1. Anything unexpected ends as a no-op and the run finishes cleanly.

Point 3 also covers users who already saved a loose pattern in their own language. They keep the ambiguity, but they stop getting the traceback.

Wiki: new English patterns, the German `[auf]` fix, a note on why the preposition is mandatory, changelog row, version bump to v 1.5.1.

## Verification

I generated every sentence each documented command can produce (`hassil.sample_expression`) and re-recognized it against the full trigger set, per language: 54 phrases for en, 54 for de, 47 for it. After the change each phrase resolves to exactly one trigger with a clean slot capture.

I also rendered the Set Volume templates over `5`, `0`, `10`, `50%`, `100%`, `up`, `down`, `banana`, `50` and `to 5`. Valid levels produce the same `volume_level` as before, and the rest skip the call.

## Two notes

- `set the volume to 50` is out of range under the existing `/10` semantics, since 50 becomes 5.0. It now does nothing instead of failing inside `media_player.volume_set`, and the same goes for a spelled-out number or a decimal comma. None of those ever worked, so this only changes how they fail.
- Mode and View have the same optional-token-before-wildcard shape (`set mode [to] {mode}`, `set view [to] {view}`) and produce the same duplicate capture. I left them alone: both matches belong to the same trigger, the clean one comes first, and requiring the preposition would break `set mode night`. Happy to tighten them in a follow-up if you want.

