### PR TITLE
Add French and Dutch weekdays and months (What time is it v 1.0.5)

### DIFF
--- a/View_Assist_custom_sentences/What_time_is_it/blueprint-whattimeisit.yaml
+++ b/View_Assist_custom_sentences/What_time_is_it/blueprint-whattimeisit.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: View Assist - What time is it
-  description: Ask Assist for time, date and day of the week and receive response (View Assist whattimeisit v 1.0.4)
+  description: Ask Assist for time, date and day of the week and receive response (View Assist whattimeisit v 1.0.5)
   domain: automation
   input:
     language:
@@ -163,7 +163,28 @@ action:
           responses:
             time: "Il est {time}"
             day_of_week: "Aujourd'hui, c'est {day_of_week}"
-            date: "Aujourd'hui, c'est {date}"
+            date: "Aujourd'hui, c'est {day_of_week} {day_of_month} {month} {year}"
+          weekdays:
+            mon: lundi
+            tue: mardi
+            wed: mercredi
+            thu: jeudi
+            fri: vendredi
+            sat: samedi
+            sun: dimanche
+          months:
+            jan: janvier
+            feb: février
+            mar: mars
+            apr: avril
+            may: mai
+            jun: juin
+            jul: juillet
+            aug: août
+            sep: septembre
+            oct: octobre
+            nov: novembre
+            dec: décembre
         it:
           responses:
             time: "Sono le {time}"
@@ -194,7 +215,28 @@ action:
           responses:
             time: "Het is {time}"
             day_of_week: "Vandaag is {day_of_week}"
-            date: "Vandaag is {date}"
+            date: "Vandaag is {day_of_week} {day_of_month} {month} {year}"
+          weekdays:
+            mon: maandag
+            tue: dinsdag
+            wed: woensdag
+            thu: donderdag
+            fri: vrijdag
+            sat: zaterdag
+            sun: zondag
+          months:
+            jan: januari
+            feb: februari
+            mar: maart
+            apr: april
+            may: mei
+            jun: juni
+            jul: juli
+            aug: augustus
+            sep: september
+            oct: oktober
+            nov: november
+            dec: december
         pl:
           responses:
             time: "Jest {time}"

--- a/wiki/docs/extend-functionality/sentences/what-time-is-it.md
+++ b/wiki/docs/extend-functionality/sentences/what-time-is-it.md
@@ -10,6 +10,7 @@ User asks for the time or the date and receives response and screen switches to 
 
 | Version | Description                  |
 | ------- | ---------------------------- |
+| v 1.0.5 | Add French and Dutch weekdays and months |
 | v 1.0.4 | Complete Italian translation |
 | v 1.0.3 | Add translations             |
 | v 1.0.2 | Add Polish translation       |


### PR DESCRIPTION
## The problem

The `date` and `dayofweek` branches always build `day_of_week_translated` and `month_translated` from `translations[language]['weekdays']` and `['months']`. The `fr` and `nl` blocks only carried `responses`, so both branches raise `UndefinedError: 'dict object' has no attribute 'weekdays'` and the run aborts.

French and Dutch users don't fall back to English on "what day is it" or "what's the date": they get no answer at all.

## Changes

- Added `weekdays` and `months` for `fr` and `nl`.
- Switched the `fr` and `nl` `date` response to the placeholder form that `de`, `it` and `pl` already use. Kept on `{date}`, the answer would have stayed English anyway, because that variable is `now().strftime('%A %B %-d')` and never passes through the translations: French users would hear "Aujourd'hui, c'est Monday August 4".
- Version bump to v 1.0.5 plus the wiki changelog row.

Two judgment calls, both easy to reverse if you disagree:

- The new entries are lowercase, unlike the other blocks. Neither French nor Dutch capitalizes weekdays or months, and both languages only interpolate them mid-sentence ("Aujourd'hui, c'est lundi", "Vandaag is maandag").
- I left the existing `fr` and `nl` response wording untouched apart from the `date` string.

## Verification

I rendered the `time`, `dayofweek` and `date` branches for all nine selectable languages across 365 days, on the current `dev` file and on the new one, with the same `Undefined` class HA's template environment installs.

- Before: `fr` and `nl` failed 365 days out of 365 on both `dayofweek` and `date`.
- After: no errors, and every weekday and month comes out right ("Aujourd'hui, c'est mardi 4 août 2026", "Vandaag is dinsdag 4 augustus 2026").
- The other seven languages render byte-identical output.

## Related gaps I found but did not touch

- `ca`, `es` and `pt` still use `{date}` in their `date` response, so they answer "Avui és Tuesday August 4" and "Hoje é Tuesday August 4". Same fix as here, but it needs a date phrasing in three languages I don't speak.
- `pl` uses the nominative: "4 Sierpień 2026" where the date wants "4 sierpnia 2026".
- Outside this blueprint, Hows the Weather offers `sr` and `sr-Latn` in its language selector with no translation blocks for either, which raises the same `UndefinedError` as this bug. I verified it, and it needs a Serbian speaker.

I opened #464 for the ca/es/pt and pl wording and #465 for the Serbian gap, rather than widening this PR. Say the word if you'd rather have any of it in here.

