### PR TITLE
Fix locate view: call view_assist.set_state, not python_script.set_state

### DIFF
--- a/View Assist dashboard and views/views/locate/locate.yaml
+++ b/View Assist dashboard and views/views/locate/locate.yaml
@@ -133,13 +133,13 @@ custom_fields:
       show_name: false
       tap_action:
         action: call-service
-        service: python_script.set_state
+        service: view_assist.set_state
         service_data:
           entity_id: '[[[ return variables.var_assistsat_entity ]]]'
           mode: hold
       double_tap_action:
         action: call-service
-        service: python_script.set_state
+        service: view_assist.set_state
         service_data:
           entity_id: '[[[ return variables.var_assistsat_entity ]]]'
           mode: normal


### PR DESCRIPTION
### The problem

The locate view's `hold_card` calls **`python_script.set_state`** on both `tap_action`
and `double_tap_action` (`views/locate/locate.yaml`, lines 136 and 142). View Assist does
not ship a python_script by that name, so on a stock install the service never resolves
and **both buttons are dead** — "hold the map for live tracking" and its release silently
do nothing.

The failure is a no-op rather than an error card, so the view still renders and nothing
appears in the UI to explain it. That is probably why it has gone unnoticed.

### Why `view_assist.set_state`

The developer docs already name it as the way to do this
(`wiki/docs/developer-resources/general-information.md`):

> Data within an automation can be set using the `view_assist.set_state` action call.

and `dashboard.yaml` does exactly that, with **byte-identical `service_data`**, from the
same button-card tap/double-tap pattern:

```yaml
tap_action:
  action: call-service
  service: view_assist.set_state
  service_data:
    entity_id: >-
      [[[ try { return variables.var_assistsat_entity } catch { return "" }]]]
    mode: hold
```

The payload needs no changes. In the integration, `set_state` is registered with
`make_entity_service_schema({str: cv.match_all}, extra=vol.ALLOW_EXTRA)`, so `mode` is
accepted as-is, and `handle_set_entity_state` routes it onto `runtime_data.default` —
where `VAMODE_REVERTS` gives `hold → {"revert": False}` and
`normal → {"revert": True, "view": "home"}`. That is precisely the hold/release behaviour
these two buttons are for, and it is behaviour a generic state-setting python_script
could not reproduce: writing the attribute onto the state machine does not reach
`runtime_data.default`, so the idle-timer revert would never see the mode change.

### Scope — what this PR does not touch

`python_script.set_state` is **not** unique to this file. It is also called by four
community-contribution blueprints (`Ask_Wolfram`, `Conversions`, `Calculations`,
`Currency_Convertor`), which look like the pre-integration idiom from before
`view_assist.set_state` existed — the hold card here was added in `35a4bc46`
(2024-09-26), predating the integration.

Worth flagging while I'm here: **no `set_state.py` ships anywhere in this repo** — the
only Python files are `viewassist-wikisearch.py`, `viewassist_wolfram_short_answer.py` and
the two Currency Convertor helpers. So those four blueprints have the same latent
dependency on a script the repo does not provide.

**I have deliberately left those alone.** They are community-maintained, their authors
may be relying on a python_script they ship or document separately, and they do not
depend on `mode` semantics the way this view does. This PR changes only the core shipped
locate view. Happy to look at the others separately if you'd want that.

### Verification

Verified on a live install (HA 2026.8.3, VA sensor entity `type: vaca`) in three
increasingly end-to-end ways:

**1. The service call the patched view makes**

```
before              : mode='normal'
tap (mode=hold)     : success=True   -> readback: mode='hold'
double-tap (normal) : success=True   -> readback: mode='normal'
```

**2. Real taps on the device.** Driving the patched view itself rather than standing in
for it — `adb input tap` on the satellite's screen, from a clean `mode='normal'` baseline:

```
baseline            : normal
single tap          : normal -> hold     (tap_action)
fast double tap     : hold   -> normal   (double_tap_action)
```

**3. The whole locate flow.** "where's Calvin" spoken at the satellite → automation
`execution=finished` → `locate_data` populated → the locate view renders the map, marker,
location text and last-update line → tap holds it, double-tap releases. Before the change
this view had never displayed anything on this install.

One note for anyone hitting this on an existing install: editing the YAML alone is not
enough — the running view lives in `.storage/lovelace.<dashboard>`, so the dashboard needs
patching too, or the view reinstalling.

### Notes

- Targeted at `dev`; `main` carries the identical lines at the same line numbers.
- Diff is +2/-2, service names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

