### PR TITLE
feat(views): add bidirectional tap-to-swap between Clock and ClockAlt views

### DIFF
--- a/View Assist dashboard and views/views/clock/clock.yaml
+++ b/View Assist dashboard and views/views/clock/clock.yaml
@@ -1,6 +1,6 @@
 type: custom:button-card
 variables:
-  clockcardversion: 1.5.1
+  clockcardversion: 1.6.0
   var_background: >-
     [[[ try {if (hass.states[variables.var_assistsat_entity] && 
     hass.states[variables.var_assistsat_entity].attributes.mode === "night")
@@ -142,7 +142,39 @@ custom_fields:
                 }
               ]]]
           - color: "[[[ return variables.var_font_color_night ]]]"
-  time: "[[[ return variables.var_current_time ]]]"
+  time:
+    card:
+      type: custom:button-card
+      name: "[[[ return variables.var_current_time ]]]"
+      tap_action:
+        action: call-service
+        service: view_assist.navigate
+        service_data:
+          device: "[[[ return variables.var_assistsat_entity ]]]"
+          path: "[[[ return `${variables.var_dashboard}/clockalt` ]]]"
+      styles:
+        card:
+          - background-color: transparent
+          - border-width: 0px
+          - width: 100%
+          - padding: 0px
+          - margin: 0px
+        name:
+          - font-size: |-
+              [[[
+                if (window.viewAssistResponsive && window.viewAssistResponsive.orientation === "portrait") {
+                  return "25vh";
+                } else {
+                  return "55vh";
+                }
+              ]]]
+          - font-weight: bold
+          - color: "[[[ return variables.var_font_color ]]]"
+          - opacity: >-
+              [[[ try {if (hass.states[variables.var_assistsat_entity] && 
+              hass.states[variables.var_assistsat_entity].attributes.mode ===
+              "night") return "35%"; else return "100%";} catch {return "100%";}
+              ]]]
   date: "[[[ return variables.var_date_short ]]]"
   night: ""
   shader: ""

--- a/View Assist dashboard and views/views/clock/clockalt.yaml
+++ b/View Assist dashboard and views/views/clock/clockalt.yaml
@@ -3,7 +3,7 @@ template:
   - variable_template
   - body_template
 variables:
-  clockaltcardversion: 1.0.0
+  clockaltcardversion: 1.1.0
   var_background: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.background} catch {
@@ -37,6 +37,12 @@ custom_fields:
       cards:
         - type: custom:button-card
           name: "[[[ return variables.var_current_time ]]]"
+          tap_action:
+            action: call-service
+            service: view_assist.navigate
+            service_data:
+              device: "[[[ return variables.var_assistsat_entity ]]]"
+              path: "[[[ return `${variables.var_dashboard}/clock` ]]]"
           styles:
             name:
               - font-size: 1000%

--- a/wiki/docs/extend-functionality/views/clock/index.md
+++ b/wiki/docs/extend-functionality/views/clock/index.md
@@ -8,9 +8,9 @@
 
 ![](./clockaltview.png)
 
-- **Description**: Provides a view for presenting the time, data and weather conditions
+- **Description**: Provides a view for presenting the time, date and weather conditions. Tapping the time text on either the Clock or ClockAlt view seamlessly swaps between the two views.
 - **Default name**: clock
-- **Current Version**: v1.0.0
+- **Current Version**: v1.6.0 (Clock) / v1.1.0 (ClockAlt)
 - **Code link**: [Clock View Raw Code](https://raw.githubusercontent.com/dinki/View-Assist/main/View%20Assist%20dashboard%20and%20views/views/clock/clock.yaml) [Clock View Alternative Raw Code](https://raw.githubusercontent.com/dinki/View-Assist/refs/heads/main/View%20Assist%20dashboard%20and%20views/views/clock/clockalt.yaml)
 - **Special Requirements**: A background image will need to be upload to the HA server and the view code modified to use it
 
@@ -20,9 +20,10 @@ Views are automatically installed courtesy of the View Assist integration
 
 ## Changelog
 
-| Version | Description                    |
-| ------- | ------------------------------ |
-| v 1.5.1 | Fix for night mode white pixel |
-| v 1.5.0 | Various improvements           |
-| v 1.4.0 | Update for better night mode   |
-| v 1.0.0 | Initial release                |
+| Version | Description                                                   |
+| ------- | ------------------------------------------------------------- |
+| v 1.6.0 | Add interactive tap to swap between Clock and ClockAlt views  |
+| v 1.5.1 | Fix for night mode white pixel                                |
+| v 1.5.0 | Various improvements                                          |
+| v 1.4.0 | Update for better night mode                                  |
+| v 1.0.0 | Initial release                                               |


### PR DESCRIPTION
## Summary

Adds interactive tap navigation between the **Clock** (`/view-assist/clock`) and **ClockAlt** (`/view-assist/clockalt`) views, allowing users to seamlessly toggle between clock styles by tapping or clicking the time text.

## Changes

- **Clock View (`views/clock/clock.yaml`)**:
  - Converted `custom_fields.time` into a responsive `custom:button-card` with `tap_action` calling `view_assist.navigate` to `${variables.var_dashboard}/clockalt`.
  - Preserved typography, responsive font sizes (`25vh` portrait / `55vh` landscape), bold font weight, color variables, and night-mode opacity dimming (`35%`).
  - Bumped `clockcardversion: 1.6.0` (minor version bump).
- **ClockAlt View (`views/clock/clockalt.yaml`)**:
  - Added `tap_action` to the time button-card calling `view_assist.navigate` to `${variables.var_dashboard}/clock`.
  - Bumped `clockaltcardversion: 1.1.0` (minor version bump).
- **Wiki Documentation (`wiki/docs/extend-functionality/views/clock/index.md`)**:
  - Documented the bidirectional tap-to-swap behavior.
  - Added `v 1.6.0` to the changelog table.

## Verification

- Tested on Home Assistant satellite device (`type: vaca`).
- Tapping time on `/view-assist/clock` navigates directly to `/view-assist/clockalt`.
- Tapping time on `/view-assist/clockalt` navigates back to `/view-assist/clock`.
- YAML syntax validated with no errors.
- Targeted at `dev` branch.