### PR TITLE
feat: add CSS view transitions and configurable transition duration

### DIFF
--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -1,7 +1,7 @@
 button_card_templates:
   variable_template:
     variables:
-      dashboardversion: 1.4.0
+      dashboardversion: 1.5.0
       var_assistsat_entity: |-
         [[[
           return localStorage.getItem("view_assist_sensor")
@@ -98,6 +98,13 @@ button_card_templates:
           try
           {
             return states[variables.var_assistsat_entity].attributes.use_24_hour_time;
+          } catch { return  false}
+        ]]]
+      var_assistsat_entity_enable_view_transitions: |
+        [[[
+          try
+          {
+            return states[variables.var_assistsat_entity].attributes.enable_view_transitions || false;
           } catch { return  false}
         ]]]
       var_title: |-
@@ -252,6 +259,42 @@ button_card_templates:
       - variable_template
       - status_icons_content
       - responsive_base
+    extra_styles: |-
+      [[[
+        try {
+          const transitionsEnabled = states[variables.var_assistsat_entity]?.attributes?.enable_view_transitions;
+          if (transitionsEnabled === true || transitionsEnabled === "true") {
+            return `
+              @keyframes vaFadeInUI {
+                0% {
+                  opacity: 0;
+                }
+                100% {
+                  opacity: 1;
+                }
+              }
+              @keyframes vaFadeOutUI {
+                0% {
+                  opacity: 1;
+                }
+                100% {
+                  opacity: 0;
+                }
+              }
+              #container {
+                animation: vaFadeInUI 0.3s ease-out forwards;
+                will-change: opacity;
+              }
+              .va-fade-out #container {
+                animation: vaFadeOutUI 0.15s ease-in forwards !important;
+              }
+            `;
+          }
+          return "";
+        } catch {
+          return "";
+        }
+      ]]]
     show_state: false
     show_icon: false
     show_name: false

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -314,7 +314,7 @@ button_card_templates:
                   animation: vaFadeInCard ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
-                :host(.va-fade-out) #card, #card.va-fade-out, .va-fade-out #card {
+                :host(.va-fade-out) #card, #card.va-fade-out {
                   animation: vaFadeOutCard ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;
@@ -340,7 +340,7 @@ button_card_templates:
                   animation: vaFadeInUI ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
-                :host(.va-fade-out) #container, #container.va-fade-out, .va-fade-out #container {
+                :host(.va-fade-out) #container, #container.va-fade-out {
                   animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -1,7 +1,7 @@
 button_card_templates:
   variable_template:
     variables:
-      dashboardversion: 1.5.1
+      dashboardversion: 1.6.0
       var_assistsat_entity: |-
         [[[
           return localStorage.getItem("view_assist_sensor")
@@ -117,6 +117,7 @@ button_card_templates:
             return (t !== undefined && t !== null && !isNaN(t)) ? parseFloat(t) : 0.5;
           } catch { return  0.5}
         ]]]
+      var_custom_background: false
       var_title: |-
         [[[
           try
@@ -279,31 +280,70 @@ button_card_templates:
             const rawTime = stateObj?.attributes?.view_transition_time ?? variables?.var_assistsat_entity_view_transition_time;
             const duration = (rawTime !== undefined && rawTime !== null && !isNaN(rawTime)) ? parseFloat(rawTime) : 0.5;
             const fadeOutDuration = Math.round((duration / 2) * 100) / 100;
-            return `
-              @keyframes vaFadeInUI {
-                0% {
-                  opacity: 0;
+
+            const isCustomBackground = Boolean(
+              variables?.var_custom_background === true ||
+              (variables?.background && variables.background !== stateObj?.attributes?.background)
+            );
+
+            const prevWasCustom = window.viewAssistPrevWasCustom ?? false;
+            window.viewAssistPrevWasCustom = isCustomBackground;
+
+            const fadeFromBlack = isCustomBackground || prevWasCustom;
+
+            if (fadeFromBlack) {
+              return `
+                @keyframes vaFadeInCard {
+                  0% {
+                    opacity: 0;
+                  }
+                  100% {
+                    opacity: 1;
+                  }
                 }
-                100% {
-                  opacity: 1;
+                @keyframes vaFadeOutCard {
+                  0% {
+                    opacity: 1;
+                  }
+                  100% {
+                    opacity: 0;
+                  }
                 }
-              }
-              @keyframes vaFadeOutUI {
-                0% {
-                  opacity: 1;
+                #card {
+                  animation: vaFadeInCard ${duration}s ease-out forwards;
+                  will-change: opacity;
                 }
-                100% {
-                  opacity: 0;
+                .va-fade-out #card {
+                  animation: vaFadeOutCard ${fadeOutDuration}s ease-in forwards !important;
                 }
-              }
-              #container {
-                animation: vaFadeInUI ${duration}s ease-out forwards;
-                will-change: opacity;
-              }
-              .va-fade-out #container {
-                animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
-              }
-            `;
+              `;
+            } else {
+              return `
+                @keyframes vaFadeInUI {
+                  0% {
+                    opacity: 0;
+                  }
+                  100% {
+                    opacity: 1;
+                  }
+                }
+                @keyframes vaFadeOutUI {
+                  0% {
+                    opacity: 1;
+                  }
+                  100% {
+                    opacity: 0;
+                  }
+                }
+                #container {
+                  animation: vaFadeInUI ${duration}s ease-out forwards;
+                  will-change: opacity;
+                }
+                .va-fade-out #container {
+                  animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
+                }
+              `;
+            }
           }
           return "";
         } catch (e) {

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -107,6 +107,14 @@ button_card_templates:
             return states[variables.var_assistsat_entity].attributes.enable_view_transitions || false;
           } catch { return  false}
         ]]]
+      var_assistsat_entity_view_transition_time: |
+        [[[
+          try
+          {
+            const t = states[variables.var_assistsat_entity].attributes.view_transition_time;
+            return (t !== undefined && t !== null && !isNaN(t)) ? parseFloat(t) : 0.5;
+          } catch { return  0.5}
+        ]]]
       var_title: |-
         [[[
           try
@@ -264,6 +272,9 @@ button_card_templates:
         try {
           const transitionsEnabled = states[variables.var_assistsat_entity]?.attributes?.enable_view_transitions;
           if (transitionsEnabled === true || transitionsEnabled === "true") {
+            const rawTime = states[variables.var_assistsat_entity]?.attributes?.view_transition_time;
+            const duration = (rawTime !== undefined && rawTime !== null && !isNaN(rawTime)) ? parseFloat(rawTime) : 0.5;
+            const fadeOutDuration = Math.round((duration / 2) * 100) / 100;
             return `
               @keyframes vaFadeInUI {
                 0% {
@@ -282,11 +293,11 @@ button_card_templates:
                 }
               }
               #container {
-                animation: vaFadeInUI 0.3s ease-out forwards;
+                animation: vaFadeInUI ${duration}s ease-out forwards;
                 will-change: opacity;
               }
               .va-fade-out #container {
-                animation: vaFadeOutUI 0.15s ease-in forwards !important;
+                animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
               }
             `;
           }

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -1,7 +1,7 @@
 button_card_templates:
   variable_template:
     variables:
-      dashboardversion: 1.5.0
+      dashboardversion: 1.5.1
       var_assistsat_entity: |-
         [[[
           return localStorage.getItem("view_assist_sensor")
@@ -104,14 +104,16 @@ button_card_templates:
         [[[
           try
           {
-            return states[variables.var_assistsat_entity].attributes.enable_view_transitions || false;
+            const s = hass?.states?.[variables.var_assistsat_entity] || (typeof states !== 'undefined' ? states?.[variables.var_assistsat_entity] : null);
+            return s?.attributes?.enable_view_transitions || false;
           } catch { return  false}
         ]]]
       var_assistsat_entity_view_transition_time: |
         [[[
           try
           {
-            const t = states[variables.var_assistsat_entity].attributes.view_transition_time;
+            const s = hass?.states?.[variables.var_assistsat_entity] || (typeof states !== 'undefined' ? states?.[variables.var_assistsat_entity] : null);
+            const t = s?.attributes?.view_transition_time;
             return (t !== undefined && t !== null && !isNaN(t)) ? parseFloat(t) : 0.5;
           } catch { return  0.5}
         ]]]
@@ -270,9 +272,11 @@ button_card_templates:
     extra_styles: |-
       [[[
         try {
-          const transitionsEnabled = states[variables.var_assistsat_entity]?.attributes?.enable_view_transitions;
+          const entityId = variables?.var_assistsat_entity || localStorage.getItem("view_assist_sensor");
+          const stateObj = hass?.states?.[entityId] || (typeof states !== 'undefined' ? states?.[entityId] : null);
+          const transitionsEnabled = stateObj?.attributes?.enable_view_transitions ?? variables?.var_assistsat_entity_enable_view_transitions;
           if (transitionsEnabled === true || transitionsEnabled === "true") {
-            const rawTime = states[variables.var_assistsat_entity]?.attributes?.view_transition_time;
+            const rawTime = stateObj?.attributes?.view_transition_time ?? variables?.var_assistsat_entity_view_transition_time;
             const duration = (rawTime !== undefined && rawTime !== null && !isNaN(rawTime)) ? parseFloat(rawTime) : 0.5;
             const fadeOutDuration = Math.round((duration / 2) * 100) / 100;
             return `
@@ -302,7 +306,7 @@ button_card_templates:
             `;
           }
           return "";
-        } catch {
+        } catch (e) {
           return "";
         }
       ]]]

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -314,7 +314,7 @@ button_card_templates:
                   animation: vaFadeInCard ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
-                :host(.va-fade-out) #card, #card.va-fade-out {
+                :host(.va-fade-out) #card, #card.va-fade-out, :host(.va-fade-out-card) #card, #card.va-fade-out-card {
                   animation: vaFadeOutCard ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;
@@ -336,12 +336,23 @@ button_card_templates:
                     opacity: 0;
                   }
                 }
+                @keyframes vaFadeOutCard {
+                  0% {
+                    opacity: 1;
+                  }
+                  100% {
+                    opacity: 0;
+                  }
+                }
                 #container {
                   animation: vaFadeInUI ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
-                :host(.va-fade-out) #container, #container.va-fade-out {
+                :host(.va-fade-out-ui) #container, #container.va-fade-out-ui {
                   animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
+                }
+                :host(.va-fade-out) #card, #card.va-fade-out, :host(.va-fade-out-card) #card, #card.va-fade-out-card {
+                  animation: vaFadeOutCard ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;
             }

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -278,8 +278,9 @@ button_card_templates:
           const transitionsEnabled = stateObj?.attributes?.enable_view_transitions ?? variables?.var_assistsat_entity_enable_view_transitions;
           if (transitionsEnabled === true || transitionsEnabled === "true") {
             const rawTime = stateObj?.attributes?.view_transition_time ?? variables?.var_assistsat_entity_view_transition_time;
-            const duration = (rawTime !== undefined && rawTime !== null && !isNaN(rawTime)) ? parseFloat(rawTime) : 0.5;
-            const fadeOutDuration = Math.round((duration / 2) * 100) / 100;
+            const totalDuration = (rawTime !== undefined && rawTime !== null && !isNaN(rawTime)) ? parseFloat(rawTime) : 0.5;
+            const fadeInDuration = Math.round((totalDuration / 2) * 100) / 100;
+            const fadeOutDuration = Math.round((totalDuration / 2) * 100) / 100;
 
             const isCustomBackground = Boolean(
               variables?.var_custom_background === true ||
@@ -310,7 +311,7 @@ button_card_templates:
                   }
                 }
                 #card {
-                  animation: vaFadeInCard ${duration}s ease-out forwards;
+                  animation: vaFadeInCard ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
                 :host(.va-fade-out) #card, #card.va-fade-out, .va-fade-out #card {
@@ -336,7 +337,7 @@ button_card_templates:
                   }
                 }
                 #container {
-                  animation: vaFadeInUI ${duration}s ease-out forwards;
+                  animation: vaFadeInUI ${fadeInDuration}s ease-out forwards;
                   will-change: opacity;
                 }
                 :host(.va-fade-out) #container, #container.va-fade-out, .va-fade-out #container {

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -313,7 +313,7 @@ button_card_templates:
                   animation: vaFadeInCard ${duration}s ease-out forwards;
                   will-change: opacity;
                 }
-                .va-fade-out #card {
+                :host(.va-fade-out) #card, #card.va-fade-out, .va-fade-out #card {
                   animation: vaFadeOutCard ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;
@@ -339,7 +339,7 @@ button_card_templates:
                   animation: vaFadeInUI ${duration}s ease-out forwards;
                   will-change: opacity;
                 }
-                .va-fade-out #container {
+                :host(.va-fade-out) #container, #container.va-fade-out, .va-fade-out #container {
                   animation: vaFadeOutUI ${fadeOutDuration}s ease-in forwards !important;
                 }
               `;

--- a/View Assist dashboard and views/dashboard/dashboard.yaml
+++ b/View Assist dashboard and views/dashboard/dashboard.yaml
@@ -287,8 +287,10 @@ button_card_templates:
               (variables?.background && variables.background !== stateObj?.attributes?.background)
             );
 
-            const prevWasCustom = window.viewAssistPrevWasCustom ?? false;
-            window.viewAssistPrevWasCustom = isCustomBackground;
+            let prevWasCustom = false;
+            try {
+              prevWasCustom = window.viewAssistPrevWasCustom === true || sessionStorage.getItem("va_prev_was_custom") === "true";
+            } catch (e) {}
 
             const fadeFromBlack = isCustomBackground || prevWasCustom;
 

--- a/View Assist dashboard and views/views/alarm/alarm.yaml
+++ b/View Assist dashboard and views/views/alarm/alarm.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  alarmcardversion: 1.1.0
+  alarmcardversion: 1.1.1
+  var_custom_background: false
   var_background: >-
     [[[ try {if (variables.var_assistsat_entity &&
     hass.states[variables.var_assistsat_entity].attributes.mode === "night")

--- a/View Assist dashboard and views/views/alert/alert.yaml
+++ b/View Assist dashboard and views/views/alert/alert.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  alertcardversion: 1.0.0
+  alertcardversion: 1.0.1
+  var_custom_background: true
   var_icon: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.alert_data['icon']}

--- a/View Assist dashboard and views/views/calendar/calendar.yaml
+++ b/View Assist dashboard and views/views/calendar/calendar.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  calendarcardversion: 1.0.0
+  calendarcardversion: 1.0.1
+  var_custom_background: false
   var_list: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.calendar_list} catch

--- a/View Assist dashboard and views/views/camera/advancedcamera.yaml
+++ b/View Assist dashboard and views/views/camera/advancedcamera.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  advancedcameracardversion: 1.1.1
+  advancedcameracardversion: 1.1.2
+  var_custom_background: false
   var_url_params: |-
     [[[
       let queryString = '';

--- a/View Assist dashboard and views/views/camera/camera.yaml
+++ b/View Assist dashboard and views/views/camera/camera.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  cameracardversion: 2.1.1
+  cameracardversion: 2.1.2
+  var_custom_background: false
   var_url_params: |-
     [[[
       let queryString = '';

--- a/View Assist dashboard and views/views/clock/clock.yaml
+++ b/View Assist dashboard and views/views/clock/clock.yaml
@@ -1,6 +1,6 @@
 type: custom:button-card
 variables:
-  clockcardversion: 1.5.1
+  clockcardversion: 1.6.0
   var_background: >-
     [[[ try {if (hass.states[variables.var_assistsat_entity] && 
     hass.states[variables.var_assistsat_entity].attributes.mode === "night")
@@ -45,6 +45,7 @@ styles:
     title:
       - display: grid
       - color: "[[[ return variables.var_font_color_night ]]]"
+      - transition: color 0.5s ease-in-out
     time:
       - display: grid
       - justify-self: center
@@ -67,6 +68,7 @@ styles:
       - color: "[[[ return variables.var_font_color ]]]"
       - padding-top: 0
       - margin-top: 0
+      - transition: opacity 0.5s ease-in-out, color 0.5s ease-in-out
     date:
       - display: grid
       - justify-self: center
@@ -82,6 +84,7 @@ styles:
           ]]]
       - width: max-content
       - color: "[[[ return variables.var_font_color_night ]]]"
+      - transition: opacity 0.5s ease-in-out, color 0.5s ease-in-out
     night:
       - position: absolute
       - top: 0

--- a/View Assist dashboard and views/views/clock/clock.yaml
+++ b/View Assist dashboard and views/views/clock/clock.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  clockcardversion: 1.6.0
+  clockcardversion: 1.6.1
+  var_custom_background: false
   var_background: >-
     [[[ try {if (hass.states[variables.var_assistsat_entity] && 
     hass.states[variables.var_assistsat_entity].attributes.mode === "night")

--- a/View Assist dashboard and views/views/clock/clockalt.yaml
+++ b/View Assist dashboard and views/views/clock/clockalt.yaml
@@ -3,7 +3,8 @@ template:
   - variable_template
   - body_template
 variables:
-  clockaltcardversion: 1.1.0
+  clockaltcardversion: 1.1.1
+  var_custom_background: false
   var_background: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.background} catch {

--- a/View Assist dashboard and views/views/clock/clockalt.yaml
+++ b/View Assist dashboard and views/views/clock/clockalt.yaml
@@ -3,7 +3,7 @@ template:
   - variable_template
   - body_template
 variables:
-  clockaltcardversion: 1.0.0
+  clockaltcardversion: 1.1.0
   var_background: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.background} catch {
@@ -29,6 +29,7 @@ styles:
       - width: max-content
       - position: absolute
       - top: 65%
+      - transition: opacity 0.5s ease-in-out
 custom_fields:
   title: ""
   clock:
@@ -41,6 +42,15 @@ custom_fields:
             name:
               - font-size: 1000%
               - text-shadow: 2px 2px black
+              - color: >-
+                  [[[ try { if (hass.states[variables.var_assistsat_entity] &&
+                  hass.states[variables.var_assistsat_entity].attributes.mode === "night")
+                  return "red"; else return "white"; } catch { return "white"; } ]]]
+              - opacity: >-
+                  [[[ try { if (hass.states[variables.var_assistsat_entity] &&
+                  hass.states[variables.var_assistsat_entity].attributes.mode === "night")
+                  return "35%"; else return "100%"; } catch { return "100%"; } ]]]
+              - transition: opacity 0.5s ease-in-out, color 0.5s ease-in-out
             card:
               - background-color: transparent
               - border-width: 0px
@@ -63,6 +73,16 @@ custom_fields:
             name:
               - font-size: 400%
               - text-shadow: 2px 2px black
+              - color: >-
+                  [[[ try { if (hass.states[variables.var_assistsat_entity] &&
+                  hass.states[variables.var_assistsat_entity].attributes.mode === "night")
+                  return "transparent"; else return "white"; } catch { return "white"; } ]]]
+              - transition: color 0.5s ease-in-out
             icon:
               - width: 80%
               - filter: drop-shadow(2px 2px black)
+              - color: >-
+                  [[[ try { if (hass.states[variables.var_assistsat_entity] &&
+                  hass.states[variables.var_assistsat_entity].attributes.mode === "night")
+                  return "transparent"; else return "white"; } catch { return "white"; } ]]]
+              - transition: color 0.5s ease-in-out

--- a/View Assist dashboard and views/views/community_contributions/clockaltwithmovement.yaml
+++ b/View Assist dashboard and views/views/community_contributions/clockaltwithmovement.yaml
@@ -3,7 +3,8 @@ template:
   - variable_template
   - body_template
 variables:
-  clockaltcardversion: 1.1.0
+  clockaltcardversion: 1.1.1
+  var_custom_background: false
   var_enable_movement: true
   var_stop_position:
     top: 50%

--- a/View Assist dashboard and views/views/community_contributions/weatherdynamic.yaml
+++ b/View Assist dashboard and views/views/community_contributions/weatherdynamic.yaml
@@ -44,7 +44,8 @@ cards:
       ### This version matches upstream to prevent the View Assist repair task
       ### from flagging it. Future upstream updates may overwrite this
       ### customised YAML.
-      weathercardversion: 1.1.1
+      weathercardversion: 1.1.2
+      var_custom_background: true
 
     template:
       - variable_template

--- a/View Assist dashboard and views/views/info/info.yaml
+++ b/View Assist dashboard and views/views/info/info.yaml
@@ -1,7 +1,8 @@
 type: custom:button-card
 variables:
   background: /view_assist/dashboard/infobackground.png
-  infocardversion: 1.0.0
+  infocardversion: 1.0.1
+  var_custom_background: true
 template:
   - variable_template
   - body_template

--- a/View Assist dashboard and views/views/infopic/infopic.yaml
+++ b/View Assist dashboard and views/views/infopic/infopic.yaml
@@ -1,7 +1,8 @@
 type: custom:button-card
 variables:
   background: /view_assist/dashboard/infobackground.png
-  infopiccardversion: 1.0.0
+  infopiccardversion: 1.0.1
+  var_custom_background: true
 template:
   - variable_template
   - body_template

--- a/View Assist dashboard and views/views/intent/intent.yaml
+++ b/View Assist dashboard and views/views/intent/intent.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  intentcardversion: 1.0.1
+  intentcardversion: 1.0.2
+  var_custom_background: true
 template:
   - variable_template
   - body_template

--- a/View Assist dashboard and views/views/list/list-nocheckbox.yaml
+++ b/View Assist dashboard and views/views/list/list-nocheckbox.yaml
@@ -1,7 +1,8 @@
 ## This view removes the checkboxes on the view
 type: custom:button-card
 variables:
-  list-nocheckboxcardversion: 1.0.2
+  list-nocheckboxcardversion: 1.0.3
+  var_custom_background: true
   var_list: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.list} catch {

--- a/View Assist dashboard and views/views/list/list.yaml
+++ b/View Assist dashboard and views/views/list/list.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  listcardversion: 1.0.2
+  listcardversion: 1.0.3
+  var_custom_background: true
   var_list: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.list} catch {

--- a/View Assist dashboard and views/views/locate/locate.yaml
+++ b/View Assist dashboard and views/views/locate/locate.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  locatecardversion: 1.0.1
+  locatecardversion: 1.0.2
+  var_custom_background: true
 template:
   - variable_template
   - body_template

--- a/View Assist dashboard and views/views/music/music-alternative.yaml
+++ b/View Assist dashboard and views/views/music/music-alternative.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  musiccardalternativeversion: 1.2.0
+  musiccardalternativeversion: 1.2.1
+  var_custom_background: true
   var_musicplayer_device: |-
     [[[
       var assistbid = localStorage.getItem("view_assist_sensor") ?? variables.default_satellite;

--- a/View Assist dashboard and views/views/music/music.yaml
+++ b/View Assist dashboard and views/views/music/music.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  musiccardversion: 1.1.1
+  musiccardversion: 1.1.2
+  var_custom_background: true
   var_musicplayer_device: |-
     [[[
       var assistbid = localStorage.getItem("view_assist_sensor");

--- a/View Assist dashboard and views/views/sports/sports.yaml
+++ b/View Assist dashboard and views/views/sports/sports.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  sportsversion: 1.1.0
+  sportsversion: 1.1.1
+  var_custom_background: true
   var_teamtracker_device: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.team_tracker} catch {

--- a/View Assist dashboard and views/views/thermostat/thermostat.yaml
+++ b/View Assist dashboard and views/views/thermostat/thermostat.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  thermostatcardversion: 1.0.2
+  thermostatcardversion: 1.0.3
+  var_custom_background: true
   var_climate_device: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.climate} catch {

--- a/View Assist dashboard and views/views/weather/weather.yaml
+++ b/View Assist dashboard and views/views/weather/weather.yaml
@@ -7,7 +7,8 @@ variables:
       return `${weather_entity}`
     ]]]    
   var_forecast_type: daily
-  weathercardversion: 1.1.0
+  weathercardversion: 1.1.1
+  var_custom_background: true
 template:
   - variable_template
   - body_template

--- a/View Assist dashboard and views/views/weather/weather.yaml
+++ b/View Assist dashboard and views/views/weather/weather.yaml
@@ -43,7 +43,11 @@ custom_fields:
       card_mod:
         style:
           .: |
-            ha-card { background: #059bf9}
+            ha-card {
+              background: transparent !important;
+              border: none !important;
+              box-shadow: none !important;
+            }
             ha-card.type-weather-forecast {
               justify-content: start !important;
             }
@@ -53,7 +57,7 @@ custom_fields:
               }
             }
             ha-card.type-weather-forecast>div.content {
-              display: flex;​
+              display: flex;
             }
           ha-card.type-weather-forecast>div.content: |
             svg {

--- a/View Assist dashboard and views/views/webpage/webpage.yaml
+++ b/View Assist dashboard and views/views/webpage/webpage.yaml
@@ -1,6 +1,7 @@
 type: custom:button-card
 variables:
-  webpageversion: "1.1.1"
+  webpageversion: "1.1.2"
+  var_custom_background: true
   var_url: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.url} catch {

--- a/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
+++ b/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
@@ -43,6 +43,7 @@ The dashboard options control different aspects of the View Assist display
   - **Menu Items** - List of status icons that are hidden in a toggleable menu
   - **Menu Timeout** - Time in seconds before menu automatically closes (0 to disable timeout)   
 - **Use 24 Hour Time** - Sets clock display to 24 hour time when enabled
+- **Enable View Transitions** - Enables smooth CSS fade transitions between views and UI state changes. Default is disabled (off) for optimal performance on low-power devices.
 - **Show/Hide Header and Side bars** - Show or hide the header and sidebar
 
         

--- a/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
+++ b/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
@@ -43,7 +43,7 @@ The dashboard options control different aspects of the View Assist display
   - **Menu Items** - List of status icons that are hidden in a toggleable menu
   - **Menu Timeout** - Time in seconds before menu automatically closes (0 to disable timeout)   
 - **Use 24 Hour Time** - Sets clock display to 24 hour time when enabled
-- **Enable View Transitions** - Enables smooth CSS fade transitions between views and UI state changes. Default is disabled (off) for optimal performance on low-power devices.
+- **Enable View Transitions** - Enables smooth CSS fade transitions between views and UI state changes. When transitioning between views that share the common satellite wallpaper (e.g. Clock and ClockAlt), only the foreground elements fade in to keep the background seamless. When transitioning to or from views with their own dedicated background/colors (e.g. Weather, Music, Info), the view smoothly fades to and from black. Default is disabled (off) for optimal performance on low-power devices.
 - **View Transition Duration** - Duration of the view transition animation in seconds (0.1s to 3.0s slider, default 0.5s).
 - **Show/Hide Header and Side bars** - Show or hide the header and sidebar
 

--- a/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
+++ b/wiki/docs/view-assist-configuration/masterconfig-configuration/dashboard-options.md
@@ -44,6 +44,7 @@ The dashboard options control different aspects of the View Assist display
   - **Menu Timeout** - Time in seconds before menu automatically closes (0 to disable timeout)   
 - **Use 24 Hour Time** - Sets clock display to 24 hour time when enabled
 - **Enable View Transitions** - Enables smooth CSS fade transitions between views and UI state changes. Default is disabled (off) for optimal performance on low-power devices.
+- **View Transition Duration** - Duration of the view transition animation in seconds (0.1s to 3.0s slider, default 0.5s).
 - **Show/Hide Header and Side bars** - Show or hide the header and sidebar
 
         


### PR DESCRIPTION
### Summary
This PR implements smooth, context-aware CSS fade transitions for View Assist view changes and mode switching, addressing https://github.com/dinki/View-Assist/issues/164.

### Background & Motivation
As discussed in https://github.com/dinki/View-Assist/issues/164:
- When changing views or mode states, abrupt visual switches can be jarring.
- **Shared Backgrounds (e.g. Clock ↔ ClockAlt)**: Fading to black when switching between views that share the same satellite wallpaper (or live slideshow camera feed) creates unnecessary screen flashes. For these views, only the foreground UI components (`#container`) fade in/out while the background remains unbroken.
- **Dedicated Backgrounds (e.g. Clock ↔ Weather / Music / Info)**: When transitioning to or from views with their own custom colors or background images, the entire view card (`#card`) smoothly fades to and from black (like the Amazon Echo Show behavior) for a polished, seamless experience.

### Key Changes
- **Context-Aware CSS Transitions (`dashboard.yaml`)**:
  - Implemented dual-mode animation logic in `body_template.extra_styles`:
    - Views sharing the satellite wallpaper animate `#container` with `@keyframes vaFadeInUI` / `@keyframes vaFadeOutUI`.
    - Views transitioning to/from dedicated backgrounds animate `#card` with `@keyframes vaFadeInCard` / `@keyframes vaFadeOutCard` (fade to/from black).
  - Tracks previous view background state via `window.viewAssistPrevWasCustom` to adapt transitions bidirectionally.
  - Dynamically respects configured duration from `attributes.view_transition_time` (default `0.5s`).
  - Added default `var_custom_background: false` to `variable_template`.
  - Feature version bump `dashboardversion` to `1.6.0`.
- **View Background Declarations & Patch Version Bumps**:
  - Declared `var_custom_background: true` on views with dedicated backgrounds (`weather.yaml`, `music.yaml`, `music-alternative.yaml`, `info.yaml`, `infopic.yaml`, `alert.yaml`, `thermostat.yaml`, `sports.yaml`, `intent.yaml`, `locate.yaml`, `webpage.yaml`, `list.yaml`, `list-nocheckbox.yaml`, and community contribution `weatherdynamic.yaml`).
  - Declared `var_custom_background: false` on views sharing the satellite wallpaper (`clock.yaml`, `clockalt.yaml`, `calendar.yaml`, `alarm.yaml`, `camera.yaml`, `advancedcamera.yaml`, and community contribution `clockaltwithmovement.yaml`).
  - Patch version bumped all 21 view definitions.
- **Clock Cards Smooth In-Place Fade (`clock.yaml` & `clockalt.yaml`)**:
  - Smooth CSS `transition` for `opacity` and `color` on time and weather items between normal and night modes.
- **Documentation (`dashboard-options.md`)**:
  - Updated documentation explaining the context-aware view transition behavior between shared wallpapers and dedicated background views.

### Related Issue & Integration PR
- Resolves https://github.com/dinki/View-Assist/issues/164
- Companion Integration PR: https://github.com/dinki/view_assist_integration/pull/268