### PR TITLE
Fix camera feed cropping on wide displays

### DIFF
--- a/View Assist dashboard and views/views/camera/camera.yaml
+++ b/View Assist dashboard and views/views/camera/camera.yaml
@@ -1,6 +1,6 @@
 type: custom:button-card
 variables:
-  cameracardversion: 2.1.0
+  cameracardversion: 2.1.1
   var_url_params: |-
     [[[
       let queryString = '';
@@ -277,6 +277,7 @@ custom_fields:
       type: picture-entity
       entity: '[[[ return variables.var_camera ]]]'
       camera_view: live
+      fit_mode: contain
       show_name: false
       show_state: false
       tap_action:


### PR DESCRIPTION
## Summary

- Set `fit_mode: contain` on the single-camera `picture-entity` card.
- Bump `cameracardversion` from `2.1.0` to `2.1.1`.

## Why

The card currently inherits Home Assistant's `cover` default, which crops part of a camera feed when its aspect ratio differs from a wide display. `contain` preserves the full image and uses letterboxing for the remaining space.

This follows the maintainer's suggestion in [discussion #476](https://github.com/dinki/View-Assist/discussions/476#discussioncomment-18201235) to make the setting part of the shipped view.

## Scope

The change applies only when one camera is open. Camera-selection thumbnails keep `camera_view: auto`, and the separate advanced-camera-card view is unchanged.

## Validation

- `git diff --check`
- Loaded the complete modified file with Ruby's YAML parser
- Confirmed no open PR or issue already proposes `fit_mode`
