### PR TITLE
Add configurable background color to alert view via var_background

### DIFF
--- a/View Assist dashboard and views/views/alert/alert.yaml
+++ b/View Assist dashboard and views/views/alert/alert.yaml
@@ -4,7 +4,7 @@ variables:
   var_icon: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.alert_data['icon']}
-    catch { return  "mdi:cancel"}]]]  
+    catch { return  "mdi:cancel"}]]]
   var_header: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.alert_data['header']}
@@ -16,20 +16,23 @@ variables:
   var_line2: >-
     [[[ try {return
     hass.states[variables.var_assistsat_entity].attributes.alert_data['line2']}
-    catch { return  "Check your settings"}]]]        
+    catch { return  "Check your settings"}]]]
+  var_background: >-
+    [[[ try {return hass.states[variables.var_assistsat_entity].attributes.alert_data['background'] || "#059bf1"}
+    catch { return "#059bf1"}]]]
 template:
   - variable_template
   - body_template
 styles:
   grid:
     - grid-template-areas: |
-        "title status"  
+        "title status"
         "alert alert"
-        "assist assist"       
+        "assist assist"
     - grid-template-columns: 1.5fr 1.5fr
     - grid-template-rows: min-content max-content
   card:
-    - background-color: "#059bf1"
+    - background-color: "[[[ return variables.var_background ]]]"
     - background-size: cover
   custom_fields:
     title:
@@ -62,7 +65,7 @@ custom_fields:
       styles:
         grid:
           - grid-template-areas: |
-              "icon header" 
+              "icon header"
               "icon line1"
               "icon line2"
           - grid-template-columns: .5fr 1fr
@@ -72,7 +75,7 @@ custom_fields:
           - align-items: center
           - padding: 2%
           - border-radius: 1vw
-          - background-color: "#059bf1"
+          - background-color: "[[[ return variables.var_background ]]]"
           - background-size: cover
           - border: none
         custom_fields:


### PR DESCRIPTION
# Alerts Page Background Color

## Summary
I wanted a way to change the alerts background color for specific automations, such as an alarm system tripping, so I can display a red background for example, or maybe yellow if it arming.  I though it could be useful for others

## Modification

Adds alert_data['background'] as an optional attribute for the alert
view. Falls back to the existing default (#059bf1) when unset, so
existing automations/blueprints that don't set this key are unaffected.
The background attribute expects valid CSS color strings and has no validation.
Also cleaned up some white spaces, sorry my VS Code automatically does this to keep code clean
